### PR TITLE
Feature/#11 회원가입 api 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/com/ops/ops/global/util/MailUtil.java
+++ b/src/main/java/com/ops/ops/global/util/MailUtil.java
@@ -1,0 +1,23 @@
+package com.ops.ops.global.util;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MailUtil {
+
+    private final JavaMailSender javaMailSender;
+
+    public void sendMail(final List<String> toUserList, final String subject, final String text) {
+        final SimpleMailMessage simpleMessage = new SimpleMailMessage();
+        simpleMessage.setTo(toUserList.toArray(new String[0]));
+        simpleMessage.setSubject(subject);
+        simpleMessage.setText(text);
+        javaMailSender.send(simpleMessage);
+    }
+}
+

--- a/src/main/java/com/ops/ops/modules/member/api/MemberController.java
+++ b/src/main/java/com/ops/ops/modules/member/api/MemberController.java
@@ -1,12 +1,15 @@
 package com.ops.ops.modules.member.api;
 
 import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 
 import com.ops.ops.modules.member.application.MemberCommandService;
+import com.ops.ops.modules.member.application.dto.request.EmailAuthConfirmRequest;
 import com.ops.ops.modules.member.application.dto.request.EmailAuthRequest;
 import com.ops.ops.modules.member.application.dto.request.SignUpRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,5 +29,11 @@ public class MemberController {
     public ResponseEntity<Void> signUpEmailAuth(final EmailAuthRequest emailAuthRequest) {
         memberCommandService.signUpEmailAuth(emailAuthRequest);
         return ResponseEntity.status(CREATED).build();
+    }
+
+    @PatchMapping("/sign-up/email-auth")
+    public ResponseEntity<Void> confirmSignUpEmailAuth(final EmailAuthConfirmRequest emailAuthConfirmRequest) {
+        memberCommandService.confirmSignUpEmailAuth(emailAuthConfirmRequest);
+        return ResponseEntity.status(NO_CONTENT).build();
     }
 }

--- a/src/main/java/com/ops/ops/modules/member/api/MemberController.java
+++ b/src/main/java/com/ops/ops/modules/member/api/MemberController.java
@@ -1,9 +1,23 @@
 package com.ops.ops.modules.member.api;
 
+import static org.springframework.http.HttpStatus.CREATED;
+
+import com.ops.ops.modules.member.application.MemberCommandService;
+import com.ops.ops.modules.member.application.dto.request.SignUpRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 public class MemberController {
+
+    private final MemberCommandService memberCommandService;
+
+    @PostMapping("/sign-up")
+    public ResponseEntity<Void> signUp(final SignUpRequest signUpRequest) {
+        memberCommandService.signUp(signUpRequest);
+        return ResponseEntity.status(CREATED).build();
+    }
 }

--- a/src/main/java/com/ops/ops/modules/member/api/MemberController.java
+++ b/src/main/java/com/ops/ops/modules/member/api/MemberController.java
@@ -3,6 +3,7 @@ package com.ops.ops.modules.member.api;
 import static org.springframework.http.HttpStatus.CREATED;
 
 import com.ops.ops.modules.member.application.MemberCommandService;
+import com.ops.ops.modules.member.application.dto.request.EmailAuthRequest;
 import com.ops.ops.modules.member.application.dto.request.SignUpRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +19,12 @@ public class MemberController {
     @PostMapping("/sign-up")
     public ResponseEntity<Void> signUp(final SignUpRequest signUpRequest) {
         memberCommandService.signUp(signUpRequest);
+        return ResponseEntity.status(CREATED).build();
+    }
+
+    @PostMapping("/sign-up/email-auth")
+    public ResponseEntity<Void> signUpEmailAuth(final EmailAuthRequest emailAuthRequest) {
+        memberCommandService.signUpEmailAuth(emailAuthRequest);
         return ResponseEntity.status(CREATED).build();
     }
 }

--- a/src/main/java/com/ops/ops/modules/member/api/MemberController.java
+++ b/src/main/java/com/ops/ops/modules/member/api/MemberController.java
@@ -7,6 +7,8 @@ import com.ops.ops.modules.member.application.MemberCommandService;
 import com.ops.ops.modules.member.application.dto.request.EmailAuthConfirmRequest;
 import com.ops.ops.modules.member.application.dto.request.EmailAuthRequest;
 import com.ops.ops.modules.member.application.dto.request.SignUpRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,18 +23,24 @@ public class MemberController {
 
     private final MemberCommandService memberCommandService;
 
+    @Operation(summary = "회원가입", description = "회원가입을 합니다. 팀장은 이미 회원가입 되어 있으므로 이메일과 비밀번호만 업데이트합니다.")
+    @ApiResponse(responseCode = "201", description = "회원가입 성공")
     @PostMapping("/sign-up")
     public ResponseEntity<Void> signUp(@Valid @RequestBody final SignUpRequest signUpRequest) {
         memberCommandService.signUp(signUpRequest);
         return ResponseEntity.status(CREATED).build();
     }
 
+    @Operation(summary = "회원가입 이메일 인증", description = "인증 코드를 발급하고, 메일을 전송합니다.")
+    @ApiResponse(responseCode = "201", description = "이메일 인증 성공")
     @PostMapping("/sign-up/email-auth")
     public ResponseEntity<Void> signUpEmailAuth(@Valid @RequestBody final EmailAuthRequest emailAuthRequest) {
         memberCommandService.signUpEmailAuth(emailAuthRequest);
         return ResponseEntity.status(CREATED).build();
     }
 
+    @Operation(summary = "회원가입 이메일 인증코드 확인", description = "인증코드를 확인합니다.")
+    @ApiResponse(responseCode = "204", description = "확인 성공")
     @PatchMapping("/sign-up/email-auth")
     public ResponseEntity<Void> confirmSignUpEmailAuth(
             @Valid @RequestBody final EmailAuthConfirmRequest emailAuthConfirmRequest) {

--- a/src/main/java/com/ops/ops/modules/member/api/MemberController.java
+++ b/src/main/java/com/ops/ops/modules/member/api/MemberController.java
@@ -7,10 +7,12 @@ import com.ops.ops.modules.member.application.MemberCommandService;
 import com.ops.ops.modules.member.application.dto.request.EmailAuthConfirmRequest;
 import com.ops.ops.modules.member.application.dto.request.EmailAuthRequest;
 import com.ops.ops.modules.member.application.dto.request.SignUpRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -20,19 +22,20 @@ public class MemberController {
     private final MemberCommandService memberCommandService;
 
     @PostMapping("/sign-up")
-    public ResponseEntity<Void> signUp(final SignUpRequest signUpRequest) {
+    public ResponseEntity<Void> signUp(@Valid @RequestBody final SignUpRequest signUpRequest) {
         memberCommandService.signUp(signUpRequest);
         return ResponseEntity.status(CREATED).build();
     }
 
     @PostMapping("/sign-up/email-auth")
-    public ResponseEntity<Void> signUpEmailAuth(final EmailAuthRequest emailAuthRequest) {
+    public ResponseEntity<Void> signUpEmailAuth(@Valid @RequestBody final EmailAuthRequest emailAuthRequest) {
         memberCommandService.signUpEmailAuth(emailAuthRequest);
         return ResponseEntity.status(CREATED).build();
     }
 
     @PatchMapping("/sign-up/email-auth")
-    public ResponseEntity<Void> confirmSignUpEmailAuth(final EmailAuthConfirmRequest emailAuthConfirmRequest) {
+    public ResponseEntity<Void> confirmSignUpEmailAuth(
+            @Valid @RequestBody final EmailAuthConfirmRequest emailAuthConfirmRequest) {
         memberCommandService.confirmSignUpEmailAuth(emailAuthConfirmRequest);
         return ResponseEntity.status(NO_CONTENT).build();
     }

--- a/src/main/java/com/ops/ops/modules/member/application/MemberCommandService.java
+++ b/src/main/java/com/ops/ops/modules/member/application/MemberCommandService.java
@@ -1,6 +1,16 @@
 package com.ops.ops.modules.member.application;
 
+import static com.ops.ops.modules.member.domain.MemberRoleType.ROLE_회원;
+import static com.ops.ops.modules.member.exception.MemberExceptionType.ALREADY_EXIST_EMAIL;
+import static com.ops.ops.modules.member.exception.MemberExceptionType.ALREADY_EXIST_STUDENT_ID;
+
+import com.ops.ops.modules.member.application.dto.request.SignUpRequest;
+import com.ops.ops.modules.member.domain.Member;
+import com.ops.ops.modules.member.domain.dao.MemberRepository;
+import com.ops.ops.modules.member.exception.MemberException;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -8,4 +18,43 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class MemberCommandService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public void signUp(final SignUpRequest request) {
+        final String encodingPassword = passwordEncoder.encode(request.password());
+
+        memberRepository.findByStudentIdAndName(request.studentId(), request.name())
+                .ifPresentOrElse(
+                        member -> member.updateTeamLeaderInfo(request.email(), encodingPassword),
+                        () -> registerNewMember(request.name(), request.studentId(), request.email(), encodingPassword)
+                );
+    }
+
+    private void registerNewMember(final String name, final String studentId, final String email,
+                                   final String password) {
+        checkIsDuplicateEmail(email);
+        checkIsDuplicateStudentId(studentId);
+
+        memberRepository.save(Member.builder()
+                .name(name)
+                .studentId(studentId)
+                .email(email)
+                .password(password)
+                .roles(Set.of(ROLE_회원))
+                .build());
+    }
+
+    private void checkIsDuplicateEmail(final String email) {
+        if (memberRepository.existsByEmail(email)) {
+            throw new MemberException(ALREADY_EXIST_EMAIL);
+        }
+    }
+
+    private void checkIsDuplicateStudentId(final String studentId) {
+        if (memberRepository.existsByStudentId(studentId)) {
+            throw new MemberException(ALREADY_EXIST_STUDENT_ID);
+        }
+    }
 }

--- a/src/main/java/com/ops/ops/modules/member/application/MemberCommandService.java
+++ b/src/main/java/com/ops/ops/modules/member/application/MemberCommandService.java
@@ -44,6 +44,7 @@ public class MemberCommandService {
     public void signUp(final SignUpRequest request) {
         final String encodingPassword = passwordEncoder.encode(request.password());
         final EmailAuth emailAuth = checkEmailAuth(request.email());
+        checkIsDuplicateEmail(request.email());
 
         memberRepository.findByStudentIdAndName(request.studentId(), request.name())
                 .ifPresentOrElse(
@@ -74,9 +75,8 @@ public class MemberCommandService {
 
     private void registerNewMember(final String name, final String studentId, final String email,
                                    final String password) {
-        checkIsDuplicateEmail(email);
         checkIsDuplicateStudentId(studentId);
-
+        
         memberRepository.save(Member.builder()
                 .name(name)
                 .studentId(studentId)

--- a/src/main/java/com/ops/ops/modules/member/application/MemberCommandService.java
+++ b/src/main/java/com/ops/ops/modules/member/application/MemberCommandService.java
@@ -7,6 +7,7 @@ import static com.ops.ops.modules.member.exception.MemberExceptionType.ALREADY_E
 import static com.ops.ops.modules.member.exception.MemberExceptionType.ALREADY_EXIST_STUDENT_ID;
 
 import com.ops.ops.global.util.MailUtil;
+import com.ops.ops.modules.member.application.dto.request.EmailAuthConfirmRequest;
 import com.ops.ops.modules.member.application.dto.request.EmailAuthRequest;
 import com.ops.ops.modules.member.application.dto.request.SignUpRequest;
 import com.ops.ops.modules.member.domain.EmailAuth;
@@ -63,6 +64,12 @@ public class MemberCommandService {
                 .token(code)
                 .build());
         sendAuthCodeMail(email, code);
+    }
+
+    public void confirmSignUpEmailAuth(final EmailAuthConfirmRequest request) {
+        final EmailAuth memberEmailAuth = emailAuthRepository.findByEmail(request.email());
+        if (memberEmailAuth.getToken().equals(request.authCode())) memberEmailAuth.correct();
+        else throw new EmailAuthException(NOT_VERIFIED_EMAIL_AUTH);
     }
 
     private void registerNewMember(final String name, final String studentId, final String email,

--- a/src/main/java/com/ops/ops/modules/member/application/MemberCommandService.java
+++ b/src/main/java/com/ops/ops/modules/member/application/MemberCommandService.java
@@ -1,12 +1,16 @@
 package com.ops.ops.modules.member.application;
 
 import static com.ops.ops.modules.member.domain.MemberRoleType.ROLE_회원;
+import static com.ops.ops.modules.member.exception.EmailAuthExceptionType.NOT_VERIFIED_EMAIL_AUTH;
 import static com.ops.ops.modules.member.exception.MemberExceptionType.ALREADY_EXIST_EMAIL;
 import static com.ops.ops.modules.member.exception.MemberExceptionType.ALREADY_EXIST_STUDENT_ID;
 
 import com.ops.ops.modules.member.application.dto.request.SignUpRequest;
+import com.ops.ops.modules.member.domain.EmailAuth;
 import com.ops.ops.modules.member.domain.Member;
+import com.ops.ops.modules.member.domain.dao.EmailAuthRepository;
 import com.ops.ops.modules.member.domain.dao.MemberRepository;
+import com.ops.ops.modules.member.exception.EmailAuthException;
 import com.ops.ops.modules.member.exception.MemberException;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -20,16 +24,21 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberCommandService {
 
     private final MemberRepository memberRepository;
+    private final EmailAuthRepository emailAuthRepository;
+
     private final PasswordEncoder passwordEncoder;
 
     public void signUp(final SignUpRequest request) {
         final String encodingPassword = passwordEncoder.encode(request.password());
+        final EmailAuth emailAuth = checkEmailAuth(request.email());
 
         memberRepository.findByStudentIdAndName(request.studentId(), request.name())
                 .ifPresentOrElse(
                         member -> member.updateTeamLeaderInfo(request.email(), encodingPassword),
                         () -> registerNewMember(request.name(), request.studentId(), request.email(), encodingPassword)
                 );
+
+        emailAuthRepository.delete(emailAuth);
     }
 
     private void registerNewMember(final String name, final String studentId, final String email,
@@ -44,6 +53,14 @@ public class MemberCommandService {
                 .password(password)
                 .roles(Set.of(ROLE_회원))
                 .build());
+    }
+
+    private EmailAuth checkEmailAuth(final String email) {
+        final EmailAuth memberEmailAuth = emailAuthRepository.findByEmail(email);
+        if (!memberEmailAuth.getIsCorrected()) {
+            throw new EmailAuthException(NOT_VERIFIED_EMAIL_AUTH);
+        }
+        return memberEmailAuth;
     }
 
     private void checkIsDuplicateEmail(final String email) {

--- a/src/main/java/com/ops/ops/modules/member/application/dto/request/EmailAuthConfirmRequest.java
+++ b/src/main/java/com/ops/ops/modules/member/application/dto/request/EmailAuthConfirmRequest.java
@@ -1,0 +1,13 @@
+package com.ops.ops.modules.member.application.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record EmailAuthConfirmRequest(
+
+        @NotNull(message = "이메일을 입력해주세요.")
+        String email,
+
+        @NotNull(message = "인증코드를 입력해주세요.")
+        String authCode
+) {
+}

--- a/src/main/java/com/ops/ops/modules/member/application/dto/request/EmailAuthRequest.java
+++ b/src/main/java/com/ops/ops/modules/member/application/dto/request/EmailAuthRequest.java
@@ -1,0 +1,10 @@
+package com.ops.ops.modules.member.application.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record EmailAuthRequest(
+
+        @NotNull(message = "이메일 입력해주세요.")
+        String email
+) {
+}

--- a/src/main/java/com/ops/ops/modules/member/application/dto/request/SignUpRequest.java
+++ b/src/main/java/com/ops/ops/modules/member/application/dto/request/SignUpRequest.java
@@ -1,0 +1,19 @@
+package com.ops.ops.modules.member.application.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record SignUpRequest(
+
+        @NotNull(message = "이름을 입력해주세요.")
+        String name,
+
+        @NotNull(message = "학번을 입력해주세요.")
+        String studentId,
+
+        @NotNull(message = "부산대 이메일을 입력해주세요.")
+        String email,
+
+        @NotNull(message = "비밀번호를 입력해주세요.")
+        String password
+) {
+}

--- a/src/main/java/com/ops/ops/modules/member/domain/EmailAuth.java
+++ b/src/main/java/com/ops/ops/modules/member/domain/EmailAuth.java
@@ -35,4 +35,8 @@ public class EmailAuth extends BaseEntity {
         this.email = email;
         this.isCorrected = false;
     }
+
+    public void correct() {
+        this.isCorrected = true;
+    }
 }

--- a/src/main/java/com/ops/ops/modules/member/domain/Member.java
+++ b/src/main/java/com/ops/ops/modules/member/domain/Member.java
@@ -15,6 +15,7 @@ import jakarta.persistence.JoinColumn;
 import java.util.HashSet;
 import java.util.Set;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
@@ -54,6 +55,7 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private Boolean isDeleted;
 
+    @Builder
     private Member(final String name, final String email, final String password, final String studentId,
                   final Set<MemberRoleType> roles) {
         this.name = name;
@@ -62,5 +64,10 @@ public class Member extends BaseEntity {
         this.studentId = studentId;
         this.roles = roles;
         this.isDeleted = false;
+    }
+
+    public void updateTeamLeaderInfo(final String email, final String password) {
+        this.email = email;
+        this.password = password;
     }
 }

--- a/src/main/java/com/ops/ops/modules/member/domain/dao/EmailAuthRepository.java
+++ b/src/main/java/com/ops/ops/modules/member/domain/dao/EmailAuthRepository.java
@@ -1,0 +1,9 @@
+package com.ops.ops.modules.member.domain.dao;
+
+import com.ops.ops.modules.member.domain.EmailAuth;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmailAuthRepository extends JpaRepository<EmailAuth, Long> {
+
+    EmailAuth findByEmail(final String email);
+}

--- a/src/main/java/com/ops/ops/modules/member/domain/dao/MemberRepository.java
+++ b/src/main/java/com/ops/ops/modules/member/domain/dao/MemberRepository.java
@@ -7,4 +7,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(final String email);
+
+    Optional<Member> findByStudentIdAndName(final String studentId, final String name);
+
+    Boolean existsByEmail(final String Email);
+
+    Boolean existsByStudentId(final String studentId);
 }

--- a/src/main/java/com/ops/ops/modules/member/exception/EmailAuthException.java
+++ b/src/main/java/com/ops/ops/modules/member/exception/EmailAuthException.java
@@ -1,0 +1,24 @@
+package com.ops.ops.modules.member.exception;
+
+import com.ops.ops.global.base.BaseException;
+import com.ops.ops.global.base.BaseExceptionType;
+
+public class EmailAuthException extends BaseException {
+
+    private final EmailAuthExceptionType exceptionType;
+
+    public EmailAuthException(final EmailAuthExceptionType exceptionType) {
+        super(exceptionType.errorMessage());
+        this.exceptionType = exceptionType;
+    }
+
+    public EmailAuthException(final EmailAuthExceptionType exceptionType, final String message) {
+        super(message);
+        this.exceptionType = exceptionType;
+    }
+
+    @Override
+    public BaseExceptionType exceptionType() {
+        return exceptionType;
+    }
+}

--- a/src/main/java/com/ops/ops/modules/member/exception/EmailAuthExceptionType.java
+++ b/src/main/java/com/ops/ops/modules/member/exception/EmailAuthExceptionType.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 public enum EmailAuthExceptionType implements BaseExceptionType {
 
-    NOT_VERIFIED_EMAIL_AUTH(HttpStatus.UNAUTHORIZED, "이메일 인증이 완료되지 않았습니다."),
+    NOT_VERIFIED_EMAIL_AUTH(HttpStatus.BAD_REQUEST, "이메일 인증이 완료되지 않았습니다."),
+    NOT_PUSAN_UNIVERSITY_EMAIL(HttpStatus.BAD_REQUEST, "부산대 이메일만 가입 가능합니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/ops/ops/modules/member/exception/EmailAuthExceptionType.java
+++ b/src/main/java/com/ops/ops/modules/member/exception/EmailAuthExceptionType.java
@@ -1,0 +1,28 @@
+package com.ops.ops.modules.member.exception;
+
+import com.ops.ops.global.base.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum EmailAuthExceptionType implements BaseExceptionType {
+
+    NOT_VERIFIED_EMAIL_AUTH(HttpStatus.UNAUTHORIZED, "이메일 인증이 완료되지 않았습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+
+    EmailAuthExceptionType(final HttpStatus httpStatus, final String errorMessage) {
+        this.httpStatus = httpStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String errorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/com/ops/ops/modules/member/exception/MemberExceptionType.java
+++ b/src/main/java/com/ops/ops/modules/member/exception/MemberExceptionType.java
@@ -6,6 +6,8 @@ import org.springframework.http.HttpStatus;
 public enum MemberExceptionType implements BaseExceptionType {
 
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."),
+    ALREADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
+    ALREADY_EXIST_STUDENT_ID(HttpStatus.BAD_REQUEST, "이미 존재하는 학번입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/ops/ops/modules/team/domain/dao/TeamRepository.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/dao/TeamRepository.java
@@ -3,8 +3,6 @@ package com.ops.ops.modules.team.domain.dao;
 import com.ops.ops.modules.team.domain.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface TeamRepository extends JpaRepository<Team, Long> {
-    Optional<Team> findByTeamIdAndIsDeletedFalse(Long teamId);
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,7 @@ spring:
   sql:
     init:
       mode: always
+
   jpa:
     hibernate:
       ddl-auto: none
@@ -19,6 +20,18 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
     show-sql: true
+
+  mail:
+    host: smtp.example.com
+    port: 587
+    username: ops-username
+    password: ops-password
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
 
 cors:
   allow:


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #11
close: #12
close: #13

## 📜 작업 내용

-회원가입 & 회원가입 이메일 인증 & 회원가입 이메일 인증코드 확인 api를 개발하였습니다.

## 💬 리뷰 요구사항

- 회원가입 flows는 다음과 같습니다.
    - 회원가입 이메일 인증 요청 -> 기입한 이메일로 메일 보냄 & EmailAuth에 토큰과 이메일 저장
    - 회원가입 이메일 인증코드 확인 -> 저장되어 있던 Auth와 요청된 Auth를 확인하여 같으면 isCorrected update
    - 회원가입
        - isCorrected가 false라면 Exception throw
        - isCorrected가 true라면
            - 학번과 name이 있다면 -> email과 password 업데이트
            - 없다면 새로 생성
        - 회원가입 로직이 끝나면 EmailAuth에 저장되어 있던 데이터 hard delete (더 이상 사용되지 않기 때문에 & 비밀번호도 같은 테이블을 이용하기 때문에)
        
+) password 규칙 & unique 제약 등은 로그인 api에 개발해둬서 로그인 pr 올릴 때 함께 올릴게용

## ✨ 기타

- 테스트 코드도 못짜고.. 메일도 계정이 없어서 테스트 못하고... sql문 만들기엔 시간이 너무 없고.... 막 짰는데 돌아갈런지.....