### PR TITLE
Feature/#9 좋아요 토글 api개발

### DIFF
--- a/src/main/java/com/ops/ops/modules/team/api/TeamLikeController.java
+++ b/src/main/java/com/ops/ops/modules/team/api/TeamLikeController.java
@@ -1,34 +1,42 @@
 package com.ops.ops.modules.team.api;
 
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.ops.ops.global.security.annotation.LoginMember;
 import com.ops.ops.modules.member.domain.Member;
 import com.ops.ops.modules.team.application.TeamLikeCommandService;
 import com.ops.ops.modules.team.application.dto.request.TeamLikeToggleRequest;
 import com.ops.ops.modules.team.application.dto.response.TeamLikeToggleResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Team Like", description = "팀 좋아요 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/teams")
 public class TeamLikeController {
 
-	private final TeamLikeCommandService teamLikeService;
+    private final TeamLikeCommandService teamLikeService;
 
-	@PatchMapping("/{teamId}/like")
-	public ResponseEntity<TeamLikeToggleResponse> toggleLike(
-		@PathVariable Long teamId,
-		@RequestBody TeamLikeToggleRequest request,
-		@LoginMember Member member
-	) {
-		TeamLikeToggleResponse response = teamLikeService.toggleLike(member.getId(), teamId, request.isLiked());
-		return ResponseEntity.ok(response);
-	}
+    @Operation(summary = "좋아요 토글", description = "특정 팀에 대해 좋아요를 등록하거나 취소합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "좋아요 상태 변경 성공"),
+        @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+        @ApiResponse(responseCode = "404", description = "존재하지 않는 팀 ID")
+    })
+    @PatchMapping("/{teamId}/like")
+    public ResponseEntity<TeamLikeToggleResponse> toggleLike(
+            @PathVariable Long teamId,
+            @RequestBody TeamLikeToggleRequest request,
+            @LoginMember Member member) {
+        TeamLikeToggleResponse response =
+                teamLikeService.toggleLike(member.getId(), teamId, request.isLiked());
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/ops/ops/modules/team/api/TeamLikeController.java
+++ b/src/main/java/com/ops/ops/modules/team/api/TeamLikeController.java
@@ -1,0 +1,34 @@
+package com.ops.ops.modules.team.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ops.ops.global.security.annotation.LoginMember;
+import com.ops.ops.modules.member.domain.Member;
+import com.ops.ops.modules.team.application.TeamLikeCommandService;
+import com.ops.ops.modules.team.application.dto.request.TeamLikeToggleRequest;
+import com.ops.ops.modules.team.application.dto.response.TeamLikeToggleResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/teams")
+public class TeamLikeController {
+
+	private final TeamLikeCommandService teamLikeService;
+
+	@PatchMapping("/{teamId}/like")
+	public ResponseEntity<TeamLikeToggleResponse> toggleLike(
+		@PathVariable Long teamId,
+		@RequestBody TeamLikeToggleRequest request,
+		@LoginMember Member member
+	) {
+		TeamLikeToggleResponse response = teamLikeService.toggleLike(member.getId(), teamId, request.isLiked());
+		return ResponseEntity.ok(response);
+	}
+}

--- a/src/main/java/com/ops/ops/modules/team/application/TeamLikeCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamLikeCommandService.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 import com.ops.ops.modules.team.application.dto.response.TeamLikeToggleResponse;
 import com.ops.ops.modules.team.domain.Team;
 import com.ops.ops.modules.team.domain.TeamLike;
-import com.ops.ops.modules.team.domain.TeamLikeRepository;
+import com.ops.ops.modules.team.domain.dao.TeamLikeRepository;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/ops/ops/modules/team/application/TeamLikeCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamLikeCommandService.java
@@ -1,0 +1,51 @@
+package com.ops.ops.modules.team.application;
+
+import org.springframework.stereotype.Service;
+
+import com.ops.ops.modules.team.application.dto.response.TeamLikeToggleResponse;
+import com.ops.ops.modules.team.domain.Team;
+import com.ops.ops.modules.team.domain.TeamLike;
+import com.ops.ops.modules.team.domain.TeamLikeRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TeamLikeCommandService {
+
+	private final TeamLikeRepository teamLikeRepository;
+	private final TeamCommandService teamCommandService;
+
+	public TeamLikeToggleResponse toggleLike(Long memberId, Long teamId, Boolean isLiked) {
+		Team team = teamCommandService.validateAndGetTeamById(teamId);
+		TeamLike teamLike = getOrCreateTeamLike(memberId, team);
+
+		// 좋아요 등록
+		if (!teamLike.getIsLiked() && isLiked) {
+			teamLike.setLiked(true);
+			return TeamLikeToggleResponse.of(team.getId(), true, "Liked successfully");
+		}
+
+		// 좋아요 취소
+		if (teamLike.getIsLiked() && !isLiked) {
+			teamLike.setLiked(false);
+			return TeamLikeToggleResponse.of(team.getId(), false, "Unliked successfully");
+		}
+
+		// 상태 변화 없음
+		return TeamLikeToggleResponse.of(team.getId(), teamLike.getIsLiked(),
+			isLiked ? "이미 좋아요한 상태입니다." : "이미 좋아요 취소한 상태입니다.");
+	}
+
+	public TeamLike createTeamLike(Long memberId, Team team) {
+		TeamLike newLike = TeamLike.of(memberId, team, true);
+		return teamLikeRepository.save(newLike);
+	}
+
+	private TeamLike getOrCreateTeamLike(Long memberId, Team team) {
+		return teamLikeRepository.findByMemberIdAndTeam(memberId, team)
+			.orElseGet(() -> createTeamLike(memberId, team));
+	}
+}

--- a/src/main/java/com/ops/ops/modules/team/application/TeamLikeCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamLikeCommandService.java
@@ -20,32 +20,31 @@ public class TeamLikeCommandService {
 
 	public TeamLikeToggleResponse toggleLike(Long memberId, Long teamId, Boolean isLiked) {
 		Team team = teamCommandService.validateAndGetTeamById(teamId);
-		TeamLike teamLike = getOrCreateTeamLike(memberId, team);
+		TeamLike teamLike = getOrCreateTeamLike(memberId, team, isLiked);
 
 		// 좋아요 등록
 		if (!teamLike.getIsLiked() && isLiked) {
 			teamLike.setLiked(true);
-			return TeamLikeToggleResponse.of(team.getId(), true, "좋아요가 등록되었습니다.");
+			return new TeamLikeToggleResponse(team.getId(), true, "좋아요가 등록되었습니다.");
 		}
 
 		// 좋아요 취소
 		if (teamLike.getIsLiked() && !isLiked) {
 			teamLike.setLiked(false);
-			return TeamLikeToggleResponse.of(team.getId(), false, "좋아요가 취소되었습니다.");
+			return new TeamLikeToggleResponse(team.getId(), false, "좋아요가 취소되었습니다.");
 		}
 
 		// 상태 변화 없음
-		return TeamLikeToggleResponse.of(team.getId(), teamLike.getIsLiked(),
+		return new TeamLikeToggleResponse(team.getId(), teamLike.getIsLiked(),
 			isLiked ? "이미 좋아요한 팀입니다." : "이미 좋아요를 취소한 팀입니다.");
 	}
 
-	public TeamLike createTeamLike(Long memberId, Team team) {
-		TeamLike newLike = TeamLike.of(memberId, team, true);
-		return teamLikeRepository.save(newLike);
+	private TeamLike getOrCreateTeamLike(Long memberId, Team team, Boolean isLiked) {
+		return teamLikeRepository.findByMemberIdAndTeam(memberId, team)
+			.orElseGet(() -> createTeamLike(memberId, team, isLiked));
 	}
 
-	private TeamLike getOrCreateTeamLike(Long memberId, Team team) {
-		return teamLikeRepository.findByMemberIdAndTeam(memberId, team)
-			.orElseGet(() -> createTeamLike(memberId, team));
+	public TeamLike createTeamLike(Long memberId, Team team, Boolean isLiked) {
+		return teamLikeRepository.save(TeamLike.of(memberId, team, isLiked));
 	}
 }

--- a/src/main/java/com/ops/ops/modules/team/application/TeamLikeCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamLikeCommandService.java
@@ -25,18 +25,18 @@ public class TeamLikeCommandService {
 		// 좋아요 등록
 		if (!teamLike.getIsLiked() && isLiked) {
 			teamLike.setLiked(true);
-			return TeamLikeToggleResponse.of(team.getId(), true, "Liked successfully");
+			return TeamLikeToggleResponse.of(team.getId(), true, "좋아요가 등록되었습니다.");
 		}
 
 		// 좋아요 취소
 		if (teamLike.getIsLiked() && !isLiked) {
 			teamLike.setLiked(false);
-			return TeamLikeToggleResponse.of(team.getId(), false, "Unliked successfully");
+			return TeamLikeToggleResponse.of(team.getId(), false, "좋아요가 취소되었습니다.");
 		}
 
 		// 상태 변화 없음
 		return TeamLikeToggleResponse.of(team.getId(), teamLike.getIsLiked(),
-			isLiked ? "이미 좋아요한 상태입니다." : "이미 좋아요 취소한 상태입니다.");
+			isLiked ? "이미 좋아요한 팀입니다." : "이미 좋아요를 취소한 팀입니다.");
 	}
 
 	public TeamLike createTeamLike(Long memberId, Team team) {

--- a/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamLikeToggleRequest.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamLikeToggleRequest.java
@@ -1,0 +1,5 @@
+package com.ops.ops.modules.team.application.dto.request;
+
+public record TeamLikeToggleRequest(
+	Boolean isLiked
+) {}

--- a/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamLikeToggleRequest.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamLikeToggleRequest.java
@@ -1,5 +1,7 @@
 package com.ops.ops.modules.team.application.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+
 public record TeamLikeToggleRequest(
-	Boolean isLiked
+	@NotNull Boolean isLiked
 ) {}

--- a/src/main/java/com/ops/ops/modules/team/application/dto/response/TeamLikeToggleResponse.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/response/TeamLikeToggleResponse.java
@@ -5,7 +5,4 @@ public record TeamLikeToggleResponse(
 	Boolean isLiked,
 	String message
 ) {
-	public static TeamLikeToggleResponse of(Long teamId, Boolean isLiked, String message) {
-		return new TeamLikeToggleResponse(teamId, isLiked, message);
-	}
 }

--- a/src/main/java/com/ops/ops/modules/team/application/dto/response/TeamLikeToggleResponse.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/response/TeamLikeToggleResponse.java
@@ -1,0 +1,11 @@
+package com.ops.ops.modules.team.application.dto.response;
+
+public record TeamLikeToggleResponse(
+	Long teamId,
+	Boolean isLiked,
+	String message
+) {
+	public static TeamLikeToggleResponse of(Long teamId, Boolean isLiked, String message) {
+		return new TeamLikeToggleResponse(teamId, isLiked, message);
+	}
+}

--- a/src/main/java/com/ops/ops/modules/team/domain/Team.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/Team.java
@@ -51,9 +51,6 @@ public class Team extends BaseEntity {
     @Column(nullable = false)
     private Boolean isSubmitted;
 
-    @Column(nullable = false)
-    private Integer likeCount;
-
     @OneToMany(mappedBy = "team")
     private List<TeamMember> teamMembers = new ArrayList<>();
 
@@ -68,7 +65,6 @@ public class Team extends BaseEntity {
         this.youTubePath = youTubePath;
         this.isDeleted = false;
         this.isSubmitted = false;
-        this.likeCount = 0;
         this.teamMembers = teamMembers;
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/TeamLike.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/TeamLike.java
@@ -34,9 +34,21 @@ public class TeamLike extends BaseEntity {
     private Boolean isLiked;
 
     @Builder
-    public TeamLike(final Long memberId, final Team team) {
+    public TeamLike(final Long memberId, final Team team, final Boolean isLiked) {
         this.memberId = memberId;
         this.team = team;
-        this.isLiked = false;
+        this.isLiked = isLiked;
+    }
+
+    public static TeamLike of(Long memberId, Team team, boolean isLiked) {
+        return TeamLike.builder()
+            .memberId(memberId)
+            .team(team)
+            .isLiked(isLiked)
+            .build();
+    }
+
+    public void setLiked(boolean liked) {
+        this.isLiked = liked;
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/TeamLikeRepository.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/TeamLikeRepository.java
@@ -1,0 +1,9 @@
+package com.ops.ops.modules.team.domain;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamLikeRepository extends JpaRepository<TeamLike, Long> {
+	Optional<TeamLike> findByMemberIdAndTeam(Long memberId, Team team);
+}

--- a/src/main/java/com/ops/ops/modules/team/domain/dao/TeamLikeRepository.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/dao/TeamLikeRepository.java
@@ -1,8 +1,11 @@
-package com.ops.ops.modules.team.domain;
+package com.ops.ops.modules.team.domain.dao;
 
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ops.ops.modules.team.domain.Team;
+import com.ops.ops.modules.team.domain.TeamLike;
 
 public interface TeamLikeRepository extends JpaRepository<TeamLike, Long> {
 	Optional<TeamLike> findByMemberIdAndTeam(Long memberId, Team team);


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #9 

## 📜 작업 내용

- 팀 좋아요 토글 API 구현 완료 및 Postman에서 테스트 완료했습니다!
- API 명세에 맞춰 요청/응답 형식 및 예외 상황을 정의하였습니다.
- Team 엔티티의 `likeCount` 필드는, 사전에 논의한 바와 같이 불필요하다고 판단하여 제거했습니다.

## 💬 리뷰 요구사항
- 솔직히 서비스 코드를 더 확장성과 가독성을 고려해 깔끔하게 구성하고 싶었지만...
   MVP 단계에서는 빠르게 기능을 완성하는 데 집중하다 보니 다소 아쉬운 점이 있습니다 ㅠ

## ✨ 기타
- 다들 화이팅입니다!
