### PR TITLE
Feature/#51 로그인한 사용자가 해당 팀의 팀장 이름과 일치 하지 않다면 예외 상황 발생

### DIFF
--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
@@ -1,20 +1,21 @@
 package com.ops.ops.modules.team.application;
 
-import static com.ops.ops.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;import static com.ops.ops.modules.team.exception.TeamExceptionType.NOT_TEAM_LEADER;
-
 import com.ops.ops.global.util.FileStorageUtil;
 import com.ops.ops.modules.file.domain.FileImageType;
 import com.ops.ops.modules.file.domain.dao.FileRepository;
-import com.ops.ops.modules.member.domain.Member;
 import com.ops.ops.modules.team.application.dto.request.TeamDetailUpdateRequest;
 import com.ops.ops.modules.team.domain.Team;
 import com.ops.ops.modules.team.domain.dao.TeamRepository;
 import com.ops.ops.modules.team.exception.TeamException;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+import static com.ops.ops.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
+import static com.ops.ops.modules.team.exception.TeamExceptionType.NOT_TEAM_MEMBER;
 
 @Service
 @RequiredArgsConstructor
@@ -60,13 +61,12 @@ public class TeamCommandService {
         return teamRepository.findById(teamId)
                 .orElseThrow(() -> new TeamException(NOT_FOUND_TEAM));
     }
-	public void updateTeamDetail(final Long teamId, final Member member, final TeamDetailUpdateRequest request) {
-		final Team team = validateAndGetTeamById(teamId);
 
-        if (!team.getLeaderName().equals(member.getName())) {
-            throw new TeamException(NOT_TEAM_LEADER);
+    public void updateTeamDetail(final Long teamId, final Long memberId, final TeamDetailUpdateRequest request) {
+        final Team team = validateAndGetTeamById(teamId);
+        if (!team.hasMember(memberId)) {
+            throw new TeamException(NOT_TEAM_MEMBER);
         }
-
-		team.updateDetail(request.overview(), request.githubPath(), request.youTubePath());
-	}
+        team.updateDetail(request.overview(), request.githubPath(), request.youTubePath());
+    }
 }

--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
@@ -62,11 +62,15 @@ public class TeamCommandService {
                 .orElseThrow(() -> new TeamException(NOT_FOUND_TEAM));
     }
 
-    public void updateTeamDetail(final Long teamId, final Long memberId, final TeamDetailUpdateRequest request) {
+    public void updateTeamDetail(final Long teamId, final Member member, final TeamDetailUpdateRequest request) {
         final Team team = validateAndGetTeamById(teamId);
-        if (!team.hasMember(memberId)) {
-            throw new TeamException(NOT_TEAM_MEMBER);
-        }
+        checkTeamLeader(member, team);
         team.updateDetail(request.overview(), request.githubPath(), request.youTubePath());
+    }
+
+    private void checkTeamLeader(final Member member, final Team team) {
+        if (!team.isTeamLeader(member)) {
+            throw new TeamException(CANNOT_MATCH_TEAM_LEADER_NAME);
+        }
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
@@ -1,10 +1,11 @@
 package com.ops.ops.modules.team.application;
 
-import static com.ops.ops.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
+import static com.ops.ops.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;import static com.ops.ops.modules.team.exception.TeamExceptionType.NOT_TEAM_LEADER;
 
 import com.ops.ops.global.util.FileStorageUtil;
 import com.ops.ops.modules.file.domain.FileImageType;
 import com.ops.ops.modules.file.domain.dao.FileRepository;
+import com.ops.ops.modules.member.domain.Member;
 import com.ops.ops.modules.team.application.dto.request.TeamDetailUpdateRequest;
 import com.ops.ops.modules.team.domain.Team;
 import com.ops.ops.modules.team.domain.dao.TeamRepository;
@@ -59,8 +60,13 @@ public class TeamCommandService {
         return teamRepository.findById(teamId)
                 .orElseThrow(() -> new TeamException(NOT_FOUND_TEAM));
     }
-	public void updateTeamDetail(final Long teamId, final Long memberId, final TeamDetailUpdateRequest request) {
+	public void updateTeamDetail(final Long teamId, final Member member, final TeamDetailUpdateRequest request) {
 		final Team team = validateAndGetTeamById(teamId);
+
+        if (!team.getLeaderName().equals(member.getName())) {
+            throw new TeamException(NOT_TEAM_LEADER);
+        }
+
 		team.updateDetail(request.overview(), request.githubPath(), request.youTubePath());
 	}
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/Team.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/Team.java
@@ -71,8 +71,7 @@ public class Team extends BaseEntity {
         this.isSubmitted = true;
     }
 
-    public boolean hasMember(Long memberId) {
-        return teamMembers.stream()
-                .anyMatch(tm -> tm.getMemberId().equals(memberId));
+    public boolean isTeamLeader(final Member member) {
+        return member != null && this.leaderName.equals(member.getName());
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/Team.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/Team.java
@@ -1,20 +1,16 @@
 package com.ops.ops.modules.team.domain;
 
 import com.ops.ops.global.base.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import java.util.ArrayList;
-import java.util.List;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -73,5 +69,10 @@ public class Team extends BaseEntity {
         this.githubPath = newGithubPath;
         this.youTubePath = newYouTubePath;
         this.isSubmitted = true;
+    }
+
+    public boolean hasMember(Long memberId) {
+        return teamMembers.stream()
+                .anyMatch(tm -> tm.getMemberId().equals(memberId));
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/dao/TeamLikeRepository.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/dao/TeamLikeRepository.java
@@ -21,5 +21,4 @@ public interface TeamLikeRepository extends JpaRepository<TeamLike, Long> {
 
 	long countByIsLikedTrue();
 
-	List<TeamLike> findByMemberIdAndTeamIn(Long id, List<Team> teams);
 }

--- a/src/main/java/com/ops/ops/modules/team/exception/TeamExceptionType.java
+++ b/src/main/java/com/ops/ops/modules/team/exception/TeamExceptionType.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 public enum TeamExceptionType implements BaseExceptionType {
     NOT_FOUND_TEAM(HttpStatus.NOT_FOUND, "팀을 찾을 수 없습니다."),
     NOT_TEAM_LEADER(HttpStatus.FORBIDDEN, "해당 팀의 팀장 권한이 없습니다."),
+    NOT_TEAM_MEMBER(HttpStatus.FORBIDDEN, "해당 팀의 멤버가 아닙니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #51 

## 📜 작업 내용

> 로그인한 사용자가 해당 팀의 팀장이 아니라면 예외 상황이 발생하도록 수정하였습니다.

## 💬 리뷰 요구사항

> 수정할 부분 있다면 말씀해주세요!

## ✨ 기타
이 pr은 대회 관련 부분 pr 승인 되면 현재 대회의 리더인지 + 이름이 같은지 확인하는 로직으로 바꾸겠습니다
