### PR TITLE
Refactor/#58 비회원은 댓글 조회가 안되도록 설정

### DIFF
--- a/src/main/java/com/ops/ops/global/security/SecurityConfig.java
+++ b/src/main/java/com/ops/ops/global/security/SecurityConfig.java
@@ -20,7 +20,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
-@EnableMethodSecurity
+@EnableMethodSecurity(securedEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
 
@@ -42,7 +42,6 @@ public class SecurityConfig {
                 .formLogin(FormLoginConfigurer::disable)
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/sign-up/**", "/sign-in/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/teams/*/comments/**").hasAnyRole("회원", "관리자", "팀장")
                         .requestMatchers(HttpMethod.GET, "/teams/**").permitAll()
                         .anyRequest().hasAnyRole("회원", "관리자", "팀장")
                 )

--- a/src/main/java/com/ops/ops/global/security/SecurityConfig.java
+++ b/src/main/java/com/ops/ops/global/security/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig {
                 .formLogin(FormLoginConfigurer::disable)
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/sign-up/**", "/sign-in/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/teams/*/comments/**").hasAnyRole("회원", "관리자", "팀장")
                         .requestMatchers(HttpMethod.GET, "/teams/**").permitAll()
                         .anyRequest().hasAnyRole("회원", "관리자", "팀장")
                 )

--- a/src/main/java/com/ops/ops/modules/team/api/TeamCommentController.java
+++ b/src/main/java/com/ops/ops/modules/team/api/TeamCommentController.java
@@ -49,8 +49,7 @@ public class TeamCommentController {
 	@ApiResponse(responseCode = "200", description = "댓글 목록 조회 성공")
 	@GetMapping
 	public ResponseEntity<List<TeamCommentResponse>> getTeamComments(
-		@Parameter(description = "팀 ID") @PathVariable final Long teamId,
-		@LoginMember final Member member
+		@Parameter(description = "팀 ID") @PathVariable final Long teamId
 	) {
 		List<TeamCommentResponse> response = teamCommentQueryService.getComments(teamId);
 		return ResponseEntity.ok(response);


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #58 

## 📜 작업 내용

비회원은 댓글 조회가 안되도록 설정하였습니다! 
1. `TeamCommentController`의 댓글 목록 조회 API를 보시면 아시겠지만, `@LoginMember` 애노테이션이 붙어있는데도 비회원 조회가 되기에 원인을 찾아보았습니다!
2. 원인은 `SecurityConfig`에서 teams관련 모든 GET API를 permitall하고 있기 떄문이었습니다! 
3. 따라서 댓글 목록 조회의 경우 인증이 필요함을 상단에 넣어 먼저 적용되도록 하였습니다.

## 💬 리뷰 요구사항

피드백은 언제나 환영입니다!

## ✨ 기타
감사합니다!