### PR TITLE
Refactor/#59 댓글 조회 api 응답수정 id값이 내림차순으로 정렬되게

### DIFF
--- a/src/main/java/com/ops/ops/global/security/SecurityConfig.java
+++ b/src/main/java/com/ops/ops/global/security/SecurityConfig.java
@@ -42,7 +42,6 @@ public class SecurityConfig {
                 .formLogin(FormLoginConfigurer::disable)
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/sign-up/**", "/sign-in/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/teams/*/comments/**").hasAnyRole("회원", "관리자", "팀장")
                         .requestMatchers(HttpMethod.GET, "/teams/**").permitAll()
                         .anyRequest().hasAnyRole("회원", "관리자", "팀장")
                 )

--- a/src/main/java/com/ops/ops/global/security/SecurityConfig.java
+++ b/src/main/java/com/ops/ops/global/security/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig {
                 .formLogin(FormLoginConfigurer::disable)
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/sign-up/**", "/sign-in/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/teams/*/comments/**").hasAnyRole("회원", "관리자", "팀장")
                         .requestMatchers(HttpMethod.GET, "/teams/**").permitAll()
                         .anyRequest().hasAnyRole("회원", "관리자", "팀장")
                 )

--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommentQueryService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommentQueryService.java
@@ -24,7 +24,7 @@ public class TeamCommentQueryService {
 
 	public List<TeamCommentResponse> getComments(final Long teamId) {
 		Team team = teamCommandService.validateAndGetTeamById(teamId);
-		List<TeamComment> comments = teamCommentRepository.findAllByTeamId(team.getId());
+		List<TeamComment> comments = teamCommentRepository.findAllByTeamIdOrderByIdDesc(team.getId());
 
 		List<Long> memberIds = comments.stream()
 			.map(TeamComment::getMemberId)

--- a/src/main/java/com/ops/ops/modules/team/domain/dao/TeamCommentRepository.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/dao/TeamCommentRepository.java
@@ -6,5 +6,5 @@ import com.ops.ops.modules.team.domain.TeamComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeamCommentRepository extends JpaRepository<TeamComment, Long> {
-	List<TeamComment> findAllByTeamId(Long id);
+	List<TeamComment> findAllByTeamIdOrderByIdDesc(Long id);
 }


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #59 

## 📜 작업 내용

댓글 목록 조회시 댓글 Id값을 기준으로 내림차순 정렬되어 조회되게 수정해주었습니다.

## 💬 리뷰 요구사항

피드백은 언제나 환영입니다!

## ✨ 기타
감사합니다!
