### PR TITLE
Feature/#80 팀원 등록 및 삭제

### DIFF
--- a/src/main/java/com/ops/ops/global/security/SecurityConfig.java
+++ b/src/main/java/com/ops/ops/global/security/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/sign-up/**", "/sign-in/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/teams/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/contests/**").permitAll()
                         .anyRequest().hasAnyRole("회원", "관리자", "팀장")
                 )
                 .exceptionHandling(exceptions -> exceptions

--- a/src/main/java/com/ops/ops/modules/member/application/convenience/MemberConvenience.java
+++ b/src/main/java/com/ops/ops/modules/member/application/convenience/MemberConvenience.java
@@ -4,6 +4,8 @@ import static com.ops.ops.modules.member.domain.MemberRoleType.ROLE_회원;
 
 import com.ops.ops.modules.member.domain.Member;
 import com.ops.ops.modules.member.domain.dao.MemberRepository;
+import com.ops.ops.modules.member.exception.MemberException;
+import com.ops.ops.modules.member.exception.MemberExceptionType;
 import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +18,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberConvenience {
 
     final private MemberRepository memberRepository;
+
+    public Member getValidateExistMember(final Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberExceptionType.NOT_FOUND_MEMBER));
+    }
 
     public Member createFakeMember(final String name) {
         final String unique = UUID.randomUUID().toString().replace("-", "").substring(0, 10);

--- a/src/main/java/com/ops/ops/modules/member/application/convenience/MemberConvenience.java
+++ b/src/main/java/com/ops/ops/modules/member/application/convenience/MemberConvenience.java
@@ -6,6 +6,7 @@ import com.ops.ops.modules.member.domain.Member;
 import com.ops.ops.modules.member.domain.dao.MemberRepository;
 import com.ops.ops.modules.member.exception.MemberException;
 import com.ops.ops.modules.member.exception.MemberExceptionType;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -26,12 +27,12 @@ public class MemberConvenience {
 
     public Member createFakeMember(final String name) {
         final String unique = UUID.randomUUID().toString().replace("-", "").substring(0, 10);
-        return memberRepository.save(Member.builder()
+        return Member.builder()
                 .name(name)
                 .studentId("fake_" + unique)
                 .email("fake_" + unique + "@placeholder.com")
                 .password("!FAKE_USER!")
-                .roles(Set.of(ROLE_회원))
-                .build());
+                .roles(new HashSet<>(Set.of(ROLE_회원)))
+                .build();
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/api/TeamMemberController.java
+++ b/src/main/java/com/ops/ops/modules/team/api/TeamMemberController.java
@@ -1,0 +1,55 @@
+package com.ops.ops.modules.team.api;
+
+import com.ops.ops.global.security.annotation.LoginMember;
+import com.ops.ops.modules.member.domain.Member;
+import com.ops.ops.modules.team.application.TeamMemberCommandService;
+import com.ops.ops.modules.team.application.dto.request.TeamMemberCreateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "팀원", description = "팀원 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/teams/{teamId}/members")
+@Secured("ROLE_관리자")
+public class TeamMemberController {
+
+    private final TeamMemberCommandService teamMemberCommandService;
+
+    @Operation(summary = "팀원 등록", description = "특정 팀에 팀원을 등록합니다.")
+    @ApiResponse(responseCode = "201", description = "팀원 등록 성공")
+    @PostMapping
+    public ResponseEntity<Void> createTeamMember(
+            @PathVariable final Long teamId,
+            @Valid @RequestBody final TeamMemberCreateRequest request,
+            @LoginMember final Member member
+    ) {
+        teamMemberCommandService.createTeamMember(teamId, request.teamMemberName());
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Operation(summary = "팀원 삭제", description = "특정 팀의 팀원을 삭제합니다. (소프트 삭제)")
+    @ApiResponse(responseCode = "204", description = "팀원 삭제 성공")
+    @DeleteMapping("/{memberId}")
+    public ResponseEntity<Void> deleteTeamMember(
+            @Parameter(description = "팀 ID") @PathVariable final Long teamId,
+            @Parameter(description = "멤버 ID") @PathVariable final Long memberId,
+            @LoginMember final Member member
+    ) {
+        teamMemberCommandService.deleteTeamMember(teamId, memberId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/ops/ops/modules/team/api/TeamMemberController.java
+++ b/src/main/java/com/ops/ops/modules/team/api/TeamMemberController.java
@@ -1,7 +1,5 @@
 package com.ops.ops.modules.team.api;
 
-import com.ops.ops.global.security.annotation.LoginMember;
-import com.ops.ops.modules.member.domain.Member;
 import com.ops.ops.modules.team.application.TeamMemberCommandService;
 import com.ops.ops.modules.team.application.dto.request.TeamMemberCreateRequest;
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,8 +32,7 @@ public class TeamMemberController {
     @PostMapping
     public ResponseEntity<Void> createTeamMember(
             @PathVariable final Long teamId,
-            @Valid @RequestBody final TeamMemberCreateRequest request,
-            @LoginMember final Member member
+            @Valid @RequestBody final TeamMemberCreateRequest request
     ) {
         teamMemberCommandService.createTeamMember(teamId, request.teamMemberName());
         return ResponseEntity.status(HttpStatus.CREATED).build();
@@ -46,8 +43,7 @@ public class TeamMemberController {
     @DeleteMapping("/{memberId}")
     public ResponseEntity<Void> deleteTeamMember(
             @Parameter(description = "팀 ID") @PathVariable final Long teamId,
-            @Parameter(description = "멤버 ID") @PathVariable final Long memberId,
-            @LoginMember final Member member
+            @Parameter(description = "멤버 ID") @PathVariable final Long memberId
     ) {
         teamMemberCommandService.deleteTeamMember(teamId, memberId);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
@@ -2,7 +2,6 @@ package com.ops.ops.modules.team.application;
 
 import static com.ops.ops.modules.file.domain.FileImageType.PREVIEW;
 import static com.ops.ops.modules.file.exception.FileExceptionType.EXCEED_PREVIEW_LIMIT;
-import static com.ops.ops.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
 
 import com.ops.ops.global.util.FileStorageUtil;
 import com.ops.ops.modules.contest.application.convenience.ContestConvenience;
@@ -14,11 +13,11 @@ import com.ops.ops.modules.file.domain.dao.FileRepository;
 import com.ops.ops.modules.file.exception.FileException;
 import com.ops.ops.modules.member.domain.Member;
 import com.ops.ops.modules.member.domain.MemberRoleType;
+import com.ops.ops.modules.team.application.convenience.TeamConvenience;
 import com.ops.ops.modules.team.application.dto.request.TeamCreateRequest;
 import com.ops.ops.modules.team.application.dto.request.TeamDetailUpdateRequest;
 import com.ops.ops.modules.team.domain.Team;
 import com.ops.ops.modules.team.domain.dao.TeamRepository;
-import com.ops.ops.modules.team.exception.TeamException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -35,6 +34,7 @@ public class TeamCommandService {
     private final FileStorageUtil fileStorageUtil;
     private final TeamMemberCommandService teamMemberCommandService;
     private final ContestConvenience contestConvenience;
+    private final TeamConvenience teamConvenience;
 
     public void saveThumbnailImage(final Long teamId, final MultipartFile image, final FileImageType thumbnailType) {
         validateExistTeam(teamId);
@@ -72,12 +72,11 @@ public class TeamCommandService {
     }
 
     private void validateExistTeam(final Long teamId) {
-        teamRepository.findById(teamId).orElseThrow(() -> new TeamException(NOT_FOUND_TEAM));
+        teamConvenience.getValidateExistTeam(teamId);
     }
 
     public Team validateAndGetTeamById(final Long teamId) {
-        return teamRepository.findById(teamId)
-                .orElseThrow(() -> new TeamException(NOT_FOUND_TEAM));
+        return teamConvenience.getValidateExistTeam(teamId);
     }
 
     public void deleteTeam(final Long teamId) {

--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
@@ -12,7 +12,6 @@ import com.ops.ops.modules.contest.exception.ContestExceptionType;
 import com.ops.ops.modules.file.domain.FileImageType;
 import com.ops.ops.modules.file.domain.dao.FileRepository;
 import com.ops.ops.modules.file.exception.FileException;
-import com.ops.ops.modules.member.application.convenience.MemberConvenience;
 import com.ops.ops.modules.member.domain.Member;
 import com.ops.ops.modules.member.domain.MemberRoleType;
 import com.ops.ops.modules.team.application.dto.request.TeamCreateRequest;
@@ -36,7 +35,6 @@ public class TeamCommandService {
     private final FileStorageUtil fileStorageUtil;
     private final TeamMemberCommandService teamMemberCommandService;
     private final ContestConvenience contestConvenience;
-    private final MemberConvenience memberConvenience;
 
     public void saveThumbnailImage(final Long teamId, final MultipartFile image, final FileImageType thumbnailType) {
         validateExistTeam(teamId);

--- a/src/main/java/com/ops/ops/modules/team/application/TeamMemberCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamMemberCommandService.java
@@ -1,5 +1,10 @@
 package com.ops.ops.modules.team.application;
 
+import com.ops.ops.modules.member.domain.Member;
+import com.ops.ops.modules.member.domain.dao.MemberRepository;
+import com.ops.ops.modules.member.exception.MemberException;
+import com.ops.ops.modules.member.exception.MemberExceptionType;
+import com.ops.ops.modules.team.domain.Team;
 import com.ops.ops.modules.team.domain.TeamMember;
 import com.ops.ops.modules.team.domain.dao.TeamMemberRepository;
 import com.ops.ops.modules.team.exception.TeamException;
@@ -14,22 +19,40 @@ import org.springframework.transaction.annotation.Transactional;
 public class TeamMemberCommandService {
     private final TeamCommandService teamCommandService;
     private final TeamMemberRepository teamMemberRepository;
+    private final MemberRepository memberRepository;
 
     public void deleteTeamMember(final Long teamId, final Long memberId) {
-        teamCommandService.validateAndGetTeamById(teamId);
+        final Team team = teamCommandService.validateAndGetTeamById(teamId);
         final TeamMember teamMember = validateAndGetMemberById(memberId);
-        validateCommentOwnership(teamMember, teamId);
+        validateMemberBelongsToTeam(teamMember, team);
         teamMemberRepository.delete(teamMember);
     }
 
     private TeamMember validateAndGetMemberById(final Long memberId) {
-        return teamMemberRepository.findById(memberId)
+        memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberExceptionType.NOT_FOUND_MEMBER));
+
+        return teamMemberRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new TeamException(TeamExceptionType.NOT_FOUND_TEAM_MEMBER));
     }
 
-    private void validateCommentOwnership(final TeamMember teamMember, final Long teamId) {
-        if (!teamMember.getTeam().getId().equals(teamId)) {
-            throw new TeamException(TeamExceptionType.NOT_FOUND_TEAM_MEMBER);
+    private void validateMemberBelongsToTeam(final TeamMember teamMember, final Team team) {
+        if (!teamMember.getTeam().equals(team)) {
+            throw new TeamException(TeamExceptionType.NOT_FOUND_TEAM_MEMBER_IN_TEAM);
         }
+    }
+
+    public void createTeamMember(final Long teamId, final String newTeamMemberName) {
+        final Team team = teamCommandService.validateAndGetTeamById(teamId);
+        team.validateDuplicatedMemberName(newTeamMemberName, memberRepository);
+
+        // 가짜 멤버 생성 및 저장
+        Member fakeMember = memberRepository.save(Member.createFake(newTeamMemberName));
+
+        // 팀에 추가 및 TeamMember 생성
+        TeamMember fakeTeamMember = team.addTeamMember(fakeMember.getId());
+
+        // 새 TeamMember 저장
+        teamMemberRepository.save(fakeTeamMember);
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/application/TeamMemberCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamMemberCommandService.java
@@ -55,10 +55,7 @@ public class TeamMemberCommandService {
     public void assignFakeTeamMember(final Team team, final String newTeamMemberName) {
         final Member newMember = memberConvenience.createFakeMember(newTeamMemberName);
         memberRepository.save(newMember);
-        final TeamMember newTeamMember = TeamMember.builder()
-                .team(team)
-                .memberId(newMember.getId())
-                .build();
+        final TeamMember newTeamMember = new TeamMember(newMember.getId(), team);
         teamMemberRepository.save(newTeamMember);
     }
 

--- a/src/main/java/com/ops/ops/modules/team/application/TeamMemberCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamMemberCommandService.java
@@ -3,6 +3,7 @@ package com.ops.ops.modules.team.application;
 import com.ops.ops.modules.member.application.convenience.MemberConvenience;
 import com.ops.ops.modules.member.domain.Member;
 import com.ops.ops.modules.member.domain.dao.MemberRepository;
+import com.ops.ops.modules.team.application.convenience.TeamConvenience;
 import com.ops.ops.modules.team.domain.Team;
 import com.ops.ops.modules.team.domain.TeamMember;
 import com.ops.ops.modules.team.domain.dao.TeamMemberRepository;
@@ -20,13 +21,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional
 public class TeamMemberCommandService {
-    private final TeamCommandService teamCommandService;
     private final TeamMemberRepository teamMemberRepository;
     private final MemberRepository memberRepository;
     private final MemberConvenience memberConvenience;
+    private final TeamConvenience teamConvenience;
 
     public void deleteTeamMember(final Long teamId, final Long memberId) {
-        final Team team = teamCommandService.validateAndGetTeamById(teamId);
+        final Team team = teamConvenience.getValidateExistTeam(teamId);
         final Member member = memberConvenience.getValidateExistMember(memberId);
         validateMemberBelongsToTeam(team, memberId);
         removeFakeTeamMemberByName(team, member.getName());
@@ -38,7 +39,7 @@ public class TeamMemberCommandService {
     }
 
     public void createTeamMember(final Long teamId, final String newTeamMemberName) {
-        final Team team = teamCommandService.validateAndGetTeamById(teamId);
+        final Team team = teamConvenience.getValidateExistTeam(teamId);
         validateDuplicatedTeamMemberName(team, newTeamMemberName);
         assignFakeTeamMember(team, newTeamMemberName);
     }

--- a/src/main/java/com/ops/ops/modules/team/application/TeamMemberCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamMemberCommandService.java
@@ -1,11 +1,8 @@
 package com.ops.ops.modules.team.application;
 
-import static com.ops.ops.modules.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
-
 import com.ops.ops.modules.member.application.convenience.MemberConvenience;
 import com.ops.ops.modules.member.domain.Member;
 import com.ops.ops.modules.member.domain.dao.MemberRepository;
-import com.ops.ops.modules.member.exception.MemberException;
 import com.ops.ops.modules.team.domain.Team;
 import com.ops.ops.modules.team.domain.TeamMember;
 import com.ops.ops.modules.team.domain.dao.TeamMemberRepository;
@@ -30,14 +27,13 @@ public class TeamMemberCommandService {
 
     public void deleteTeamMember(final Long teamId, final Long memberId) {
         final Team team = teamCommandService.validateAndGetTeamById(teamId);
-        final Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
+        final Member member = memberConvenience.getValidateExistMember(memberId);
         validateMemberBelongsToTeam(team, memberId);
         removeFakeTeamMemberByName(team, member.getName());
     }
 
     private void validateMemberBelongsToTeam(final Team team, final Long memberId) {
-        final TeamMember teamMember = teamMemberRepository.findByMemberIdAndTeam(memberId, team)
+        teamMemberRepository.findByMemberIdAndTeam(memberId, team)
                 .orElseThrow(() -> new TeamException(TeamExceptionType.NOT_FOUND_TEAM_MEMBER));
     }
 
@@ -56,7 +52,8 @@ public class TeamMemberCommandService {
     }
 
     public void assignFakeTeamMember(final Team team, final String newTeamMemberName) {
-        final Member newMember = memberRepository.saveAndFlush(memberConvenience.createFakeMember(newTeamMemberName));
+        final Member newMember = memberConvenience.createFakeMember(newTeamMemberName);
+        memberRepository.save(newMember);
         final TeamMember newTeamMember = team.addTeamMember(newMember.getId());
         teamMemberRepository.save(newTeamMember);
     }

--- a/src/main/java/com/ops/ops/modules/team/application/TeamMemberCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamMemberCommandService.java
@@ -55,7 +55,10 @@ public class TeamMemberCommandService {
     public void assignFakeTeamMember(final Team team, final String newTeamMemberName) {
         final Member newMember = memberConvenience.createFakeMember(newTeamMemberName);
         memberRepository.save(newMember);
-        final TeamMember newTeamMember = team.addTeamMember(newMember.getId());
+        final TeamMember newTeamMember = TeamMember.builder()
+                .team(team)
+                .memberId(newMember.getId())
+                .build();
         teamMemberRepository.save(newTeamMember);
     }
 

--- a/src/main/java/com/ops/ops/modules/team/application/TeamMemberCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamMemberCommandService.java
@@ -1,0 +1,35 @@
+package com.ops.ops.modules.team.application;
+
+import com.ops.ops.modules.team.domain.TeamMember;
+import com.ops.ops.modules.team.domain.dao.TeamMemberRepository;
+import com.ops.ops.modules.team.exception.TeamException;
+import com.ops.ops.modules.team.exception.TeamExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TeamMemberCommandService {
+    private final TeamCommandService teamCommandService;
+    private final TeamMemberRepository teamMemberRepository;
+
+    public void deleteTeamMember(final Long teamId, final Long memberId) {
+        teamCommandService.validateAndGetTeamById(teamId);
+        final TeamMember teamMember = validateAndGetMemberById(memberId);
+        validateCommentOwnership(teamMember, teamId);
+        teamMemberRepository.delete(teamMember);
+    }
+
+    private TeamMember validateAndGetMemberById(final Long memberId) {
+        return teamMemberRepository.findById(memberId)
+                .orElseThrow(() -> new TeamException(TeamExceptionType.NOT_FOUND_TEAM_MEMBER));
+    }
+
+    private void validateCommentOwnership(final TeamMember teamMember, final Long teamId) {
+        if (!teamMember.getTeam().getId().equals(teamId)) {
+            throw new TeamException(TeamExceptionType.NOT_FOUND_TEAM_MEMBER);
+        }
+    }
+}

--- a/src/main/java/com/ops/ops/modules/team/application/TeamQueryService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamQueryService.java
@@ -128,7 +128,8 @@ public class TeamQueryService {
     }
 
     public TeamSubmissionStatusResponse getSubmissionStatus(final Member member) {
-        TeamMember teamMember = teamMemberRepository.findByMemberId(member.getId());
+        TeamMember teamMember = teamMemberRepository.findByMemberId(member.getId())
+                .orElseThrow(() -> new TeamException(TeamExceptionType.NOT_FOUND_TEAM_MEMBER));
         Team team = teamMember.getTeam();
 
         return TeamSubmissionStatusResponse.fromEntity(team);

--- a/src/main/java/com/ops/ops/modules/team/application/convenience/TeamConvenience.java
+++ b/src/main/java/com/ops/ops/modules/team/application/convenience/TeamConvenience.java
@@ -1,0 +1,21 @@
+package com.ops.ops.modules.team.application.convenience;
+
+import com.ops.ops.modules.team.domain.Team;
+import com.ops.ops.modules.team.domain.dao.TeamRepository;
+import com.ops.ops.modules.team.exception.TeamException;
+import com.ops.ops.modules.team.exception.TeamExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeamConvenience {
+    private final TeamRepository teamRepository;
+
+    public Team getValidateExistTeam(Long teamId) {
+        return teamRepository.findById(teamId)
+                .orElseThrow(() -> new TeamException(TeamExceptionType.NOT_FOUND_TEAM));
+    }
+}

--- a/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamMemberCreateRequest.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamMemberCreateRequest.java
@@ -3,6 +3,6 @@ package com.ops.ops.modules.team.application.dto.request;
 import jakarta.validation.constraints.NotBlank;
 
 public record TeamMemberCreateRequest(
-        @NotBlank String teamMemberName
+        @NotBlank(message = "추가할 팀원명은 비어 있을 수 없습니다.") String teamMemberName
 ) {
 }

--- a/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamMemberCreateRequest.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamMemberCreateRequest.java
@@ -1,0 +1,8 @@
+package com.ops.ops.modules.team.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TeamMemberCreateRequest(
+        @NotBlank String teamMemberName
+) {
+}

--- a/src/main/java/com/ops/ops/modules/team/domain/Team.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/Team.java
@@ -118,13 +118,4 @@ public class Team extends BaseEntity {
     public boolean isLeaderNameChanged(String newLeaderName) {
         return !this.getLeaderName().equals(newLeaderName);
     }
-
-    public TeamMember addTeamMember(Long memberId) {
-        TeamMember newLeader = TeamMember.builder()
-                .memberId(memberId)
-                .team(this)
-                .build();
-        this.teamMembers.add(newLeader);
-        return newLeader;
-    }
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/Team.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/Team.java
@@ -181,4 +181,17 @@ public class Team extends BaseEntity {
 
         this.contest = newContest;
     }
+
+    public void validateDuplicatedMemberName(String newMemberName, MemberRepository memberRepository) {
+        boolean duplicated = this.teamMembers.stream()
+                .filter(tm -> !tm.getIsDeleted())
+                .anyMatch(tm -> memberRepository.findById(tm.getMemberId())
+                        .map(Member::getName)
+                        .filter(name -> name.equals(newMemberName))
+                        .isPresent());
+
+        if (duplicated) {
+            throw new TeamException(TeamExceptionType.DUPLICATED_MEMBER_NAME);
+        }
+    }
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/Team.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/Team.java
@@ -62,8 +62,7 @@ public class Team extends BaseEntity {
 
     @Builder
     public Team(final String leaderName, final String teamName, final String projectName, final String overview,
-                final String productionPath, final String githubPath, final String youTubePath,
-                final List<TeamMember> teamMembers, final Long contestId) {
+                final String productionPath, final String githubPath, final String youTubePath, final Long contestId) {
         this.leaderName = leaderName;
         this.teamName = teamName;
         this.projectName = projectName;
@@ -73,7 +72,7 @@ public class Team extends BaseEntity {
         this.youTubePath = youTubePath;
         this.isDeleted = false;
         this.isSubmitted = false;
-        this.teamMembers = teamMembers;
+        this.teamMembers = new ArrayList<>();
         this.contestId = contestId;
     }
 
@@ -87,7 +86,6 @@ public class Team extends BaseEntity {
                 .productionPath(productionPath)
                 .githubPath(githubPath)
                 .youTubePath(youTubePath)
-                .teamMembers(new ArrayList<>())
                 .contestId(contestId)
                 .build();
     }

--- a/src/main/java/com/ops/ops/modules/team/domain/dao/TeamMemberRepository.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/dao/TeamMemberRepository.java
@@ -1,12 +1,12 @@
 package com.ops.ops.modules.team.domain.dao;
 
-import com.ops.ops.modules.team.domain.TeamComment;
 import com.ops.ops.modules.team.domain.TeamMember;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     List<TeamMember> findAllByTeamId(Long id);
-    TeamMember findByMemberId(Long id);
+
+    Optional<TeamMember> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/dao/TeamMemberRepository.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/dao/TeamMemberRepository.java
@@ -1,15 +1,15 @@
 package com.ops.ops.modules.team.domain.dao;
 
+import com.ops.ops.modules.team.domain.Team;
 import com.ops.ops.modules.team.domain.TeamMember;
 import java.util.List;
-import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     List<TeamMember> findAllByTeamId(Long id);
 
-    TeamMember findByMemberId(Long id);
-
     Optional<TeamMember> findByMemberId(Long memberId);
+
+    Optional<TeamMember> findByMemberIdAndTeam(Long memberId, Team team);
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/dao/TeamRepository.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/dao/TeamRepository.java
@@ -4,9 +4,6 @@ import com.ops.ops.modules.team.domain.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Optional;
-
 @Repository
 public interface TeamRepository extends JpaRepository<Team, Long> {
 }

--- a/src/main/java/com/ops/ops/modules/team/exception/TeamExceptionType.java
+++ b/src/main/java/com/ops/ops/modules/team/exception/TeamExceptionType.java
@@ -6,7 +6,10 @@ import org.springframework.http.HttpStatus;
 public enum TeamExceptionType implements BaseExceptionType {
     NOT_FOUND_TEAM(HttpStatus.NOT_FOUND, "팀을 찾을 수 없습니다."),
     NOT_TEAM_LEADER(HttpStatus.FORBIDDEN, "해당 팀의 팀장 권한이 없습니다."),
-    NOT_FOUND_TEAM_MEMBER(HttpStatus.NOT_FOUND, "팀원을 찾을 수 없습니다.");
+    NOT_FOUND_TEAM_MEMBER(HttpStatus.NOT_FOUND, "팀원을 찾을 수 없습니다."),
+    NOT_FOUND_TEAM_MEMBER_IN_TEAM(HttpStatus.NOT_FOUND, "해당 팀에 속해있지 않습니다."),
+    DUPLICATED_MEMBER_NAME(HttpStatus.CONFLICT, "팀 내에 동일한 이름을 가진 팀원이 있습니다."),
+    ;
 
     private final HttpStatus httpStatus;
     private final String errorMessage;


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #80 

## 📜 작업 내용

> 팀원 등록 및 삭제 api를 작성했습니다. 등록 시 전달받은 이름을 기반으로 가짜 계정을 만들어서 매핑합니다.

## 💬 리뷰 요구사항

> 수정해야할 부분 있다면 말씀해주세요!!

## ✨ 기타
