### PR TITLE
Refactor/#77 관리자페이지 주요 기능들을 이번 대회 기준으로 바꾸기

### DIFF
--- a/src/main/java/com/ops/ops/modules/contest/domain/dao/ContestRepository.java
+++ b/src/main/java/com/ops/ops/modules/contest/domain/dao/ContestRepository.java
@@ -1,5 +1,7 @@
 package com.ops.ops.modules.contest.domain.dao;
 
+import java.util.Optional;
+
 import com.ops.ops.modules.contest.domain.Contest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -7,4 +9,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ContestRepository extends JpaRepository<Contest, Long> {
     boolean existsByContestName(String contestName);
+
+    Optional<Contest> findByIsCurrentTrue();
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/dao/TeamLikeRepository.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/dao/TeamLikeRepository.java
@@ -13,15 +13,14 @@ import com.ops.ops.modules.team.domain.TeamLike;
 public interface TeamLikeRepository extends JpaRepository<TeamLike, Long> {
 	Optional<TeamLike> findByMemberIdAndTeam(Long memberId, Team team);
 
-	@Query("SELECT t.team.id AS teamId, COUNT(t) AS likeCount FROM TeamLike t WHERE t.isLiked = true GROUP BY t.team.id")
-	List<TeamLikeCountDto> findTeamLikeCountGrouped();
+	@Query("SELECT t.team.id AS teamId, COUNT(t) AS likeCount FROM TeamLike t WHERE t.isLiked = true AND t.team IN :teams GROUP BY t.team.id")
+	List<TeamLikeCountDto> findTeamLikeCountGroupedByTeams(List<Team> teams);
 
-	@Query("SELECT COUNT(DISTINCT t.memberId) FROM TeamLike t WHERE t.isLiked = true")
-	long countDistinctMemberIdsByIsLikedTrue();
+	@Query("SELECT COUNT(DISTINCT t.memberId) FROM TeamLike t WHERE t.isLiked = true AND t.team IN :teams")
+	long countDistinctMemberIdsByIsLikedTrueAndTeams(List<Team> teams);
 
-	long countByIsLikedTrue();
-
-	List<TeamLike> findByMemberIdAndTeamIn(Long id, List<Team> teams);
+	@Query("SELECT COUNT(t) FROM TeamLike t WHERE t.isLiked = true AND t.team IN :teams")
+	long countByIsLikedTrueAndTeams(List<Team> teams);
 
 	List<TeamLike> findAllByMemberIdAndTeamIn(Long id, List<Team> teams);
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/dao/TeamRepository.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/dao/TeamRepository.java
@@ -4,7 +4,10 @@ import com.ops.ops.modules.team.domain.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface TeamRepository extends JpaRepository<Team, Long> {
     boolean existsByContestId(Long contestId);
+    List<Team> findByContestId(Long contestId);
 }


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #77 

## 📜 작업 내용

 Contest의 isCurrent 필드값이 true 상태인 현재 대회(6회 창의융합대회) 팀 데이터만 조회하도록 수정되었습니다.

## 💬 리뷰 요구사항

추후에 아래와 같은 과정을 걸칠듯합니다!
1. 6회 창의융합 대회 만들기
2. 6회 창의융합 대회의 여러 팀 디비에 직접 추가하기  
3. 2.에서 만든 팀들에 대한 투표 현황을 관리자 페이지에서 조회해야하므로 1.에서 만든, isCurrent = true인 대회들을 조회하기!

포스트맨으로 테스트 완료하였습니다~!

## ✨ 기타
화이팅~!!!