### PR TITLE
Refactor/#86 전반적인 코드 리팩토링

### DIFF
--- a/src/main/java/com/ops/ops/modules/contest/api/ContestController.java
+++ b/src/main/java/com/ops/ops/modules/contest/api/ContestController.java
@@ -1,5 +1,7 @@
 package com.ops.ops.modules.contest.api;
 
+import static org.springframework.http.HttpStatus.CREATED;
+
 import com.ops.ops.global.security.annotation.LoginMember;
 import com.ops.ops.modules.contest.application.ContestCommandService;
 import com.ops.ops.modules.contest.application.ContestQueryService;
@@ -14,7 +16,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -50,7 +51,7 @@ public class ContestController {
             @Valid @RequestBody final ContestRequest request
     ) {
         contestCommandService.createContest(request.contestName());
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return ResponseEntity.status(CREATED).build();
     }
 
     @Operation(summary = "대회 수정", description = "특정 대회의 정보를 수정합니다.")

--- a/src/main/java/com/ops/ops/modules/contest/application/ContestCommandService.java
+++ b/src/main/java/com/ops/ops/modules/contest/application/ContestCommandService.java
@@ -3,9 +3,7 @@ package com.ops.ops.modules.contest.application;
 import com.ops.ops.modules.contest.application.convenience.ContestConvenience;
 import com.ops.ops.modules.contest.domain.Contest;
 import com.ops.ops.modules.contest.domain.dao.ContestRepository;
-import com.ops.ops.modules.contest.exception.ContestException;
-import com.ops.ops.modules.contest.exception.ContestExceptionType;
-import com.ops.ops.modules.team.domain.dao.TeamRepository;
+import com.ops.ops.modules.team.application.convenience.TeamConvenience;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,11 +13,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class ContestCommandService {
     private final ContestRepository contestRepository;
-    private final TeamRepository teamRepository;
+
     private final ContestConvenience contestConvenience;
+    private final TeamConvenience teamConvenience;
 
     public void createContest(final String contestName) {
-        validateDuplicateContestName(contestName);
+        contestConvenience.validateDuplicateContestName(contestName);
         // 만약 제 6회 창의융합 대회를 직접 등록하는 상황일 때 isCurrent를 true로 설정하도록
         final boolean isCurrent = contestName.contains("6회") && contestName.contains("창의융합");
         final Contest contest = Contest.builder()
@@ -29,23 +28,15 @@ public class ContestCommandService {
         contestRepository.save(contest);
     }
 
-    private void validateDuplicateContestName(String contestName) {
-        if (contestRepository.existsByContestName(contestName)) {
-            throw new ContestException(ContestExceptionType.CONTEST_NAME_ALREADY_EXIST);
-        }
-    }
-
     public void updateContest(final Long contestId, final String newContestName) {
-        validateDuplicateContestName(newContestName);
+        contestConvenience.validateDuplicateContestName(newContestName);
         final Contest contest = contestConvenience.getValidateExistContest(contestId);
         contest.updateContestName(newContestName);
     }
 
     public void deleteContest(final Long contestId) {
         final Contest contest = contestConvenience.getValidateExistContest(contestId);
-        if (teamRepository.existsByContestId(contestId)) {
-            throw new ContestException(ContestExceptionType.CONTEST_HAS_TEAMS);
-        }
+        teamConvenience.checkAllContestDelete(contestId);
         contestRepository.delete(contest);
     }
 }

--- a/src/main/java/com/ops/ops/modules/contest/application/ContestCommandService.java
+++ b/src/main/java/com/ops/ops/modules/contest/application/ContestCommandService.java
@@ -18,7 +18,7 @@ public class ContestCommandService {
     private final TeamConvenience teamConvenience;
 
     public void createContest(final String contestName) {
-        contestConvenience.validateDuplicateContestName(contestName);
+        contestConvenience.checkDuplicateContestName(contestName);
         // 만약 제 6회 창의융합 대회를 직접 등록하는 상황일 때 isCurrent를 true로 설정하도록
         final boolean isCurrent = contestName.contains("6회") && contestName.contains("창의융합");
         final Contest contest = Contest.builder()
@@ -29,7 +29,7 @@ public class ContestCommandService {
     }
 
     public void updateContest(final Long contestId, final String newContestName) {
-        contestConvenience.validateDuplicateContestName(newContestName);
+        contestConvenience.checkDuplicateContestName(newContestName);
         final Contest contest = contestConvenience.getValidateExistContest(contestId);
         contest.updateContestName(newContestName);
     }

--- a/src/main/java/com/ops/ops/modules/contest/application/ContestQueryService.java
+++ b/src/main/java/com/ops/ops/modules/contest/application/ContestQueryService.java
@@ -1,15 +1,16 @@
 package com.ops.ops.modules.contest.application;
 
+import static com.ops.ops.modules.contest.exception.ContestExceptionType.NOT_FOUND_CURRENT_CONTEST;
+
 import com.ops.ops.modules.contest.application.dto.response.ContestResponse;
 import com.ops.ops.modules.contest.domain.Contest;
 import com.ops.ops.modules.contest.domain.dao.ContestRepository;
 import com.ops.ops.modules.contest.exception.ContestException;
-import com.ops.ops.modules.contest.exception.ContestExceptionType;
 import com.ops.ops.modules.member.domain.Member;
-import com.ops.ops.modules.team.application.TeamQueryService;
+import com.ops.ops.modules.team.application.convenience.TeamConvenience;
+import com.ops.ops.modules.team.application.convenience.TeamLikeConvenience;
 import com.ops.ops.modules.team.application.dto.response.TeamSummaryResponse;
 import com.ops.ops.modules.team.domain.Team;
-import com.ops.ops.modules.team.domain.dao.TeamRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,9 +20,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ContestQueryService {
+
     private final ContestRepository contestRepository;
-    private final TeamRepository teamRepository;
-    private final TeamQueryService teamQueryService;
+
+    private final TeamConvenience teamConvenience;
+    private final TeamLikeConvenience teamLikeConvenience;
 
     public List<ContestResponse> getAllContests() {
         List<Contest> contests = contestRepository.findAll();
@@ -37,18 +40,18 @@ public class ContestQueryService {
 
 
     public List<TeamSummaryResponse> getContestTeamSummaries(final Long contestId, final Member member) {
-        final List<Team> teams = teamRepository.findByContestId(contestId);
-        return teamQueryService.getAllTeamSummaries(teams, member);
+        final List<Team> teams = teamConvenience.findAllByContestId(contestId);
+        return teamLikeConvenience.getAllTeamSummaries(teams, member);
     }
 
     public List<TeamSummaryResponse> getCurrentContestTeamSummaries(final Member member) {
         final List<Team> teams = findTeamsOfCurrentContest();
-        return teamQueryService.getAllTeamSummaries(teams, member);
+        return teamLikeConvenience.getAllTeamSummaries(teams, member);
     }
 
-    public List<Team> findTeamsOfCurrentContest() {
+    private List<Team> findTeamsOfCurrentContest() {
         final Contest contest = contestRepository.findByIsCurrentTrue()
-                .orElseThrow(() -> new ContestException(ContestExceptionType.NOT_FOUND_CURRENT_CONTEST));
-        return teamRepository.findByContestId(contest.getId());
+                .orElseThrow(() -> new ContestException(NOT_FOUND_CURRENT_CONTEST));
+        return teamConvenience.findAllByContestId(contest.getId());
     }
 }

--- a/src/main/java/com/ops/ops/modules/contest/application/convenience/ContestConvenience.java
+++ b/src/main/java/com/ops/ops/modules/contest/application/convenience/ContestConvenience.java
@@ -1,6 +1,7 @@
 package com.ops.ops.modules.contest.application.convenience;
 
 import static com.ops.ops.modules.contest.exception.ContestExceptionType.CANNOT_UPDATE_TEAM_INFO_FOR_CURRENT;
+import static com.ops.ops.modules.contest.exception.ContestExceptionType.CONTEST_NAME_ALREADY_EXIST;
 import static com.ops.ops.modules.contest.exception.ContestExceptionType.NOT_FOUND_CONTEST;
 
 import com.ops.ops.modules.contest.domain.Contest;
@@ -18,12 +19,10 @@ public class ContestConvenience {
     private final ContestRepository contestRepository;
 
     public Contest getValidateExistContest(final Long contestId) {
-        return contestRepository.findById(contestId)
-                .orElseThrow(() -> new ContestException(NOT_FOUND_CONTEST));
+        return contestRepository.findById(contestId).orElseThrow(() -> new ContestException(NOT_FOUND_CONTEST));
     }
 
-    public void validateNotCurrentContest(final Long contestId) {
-        Contest contest = getValidateExistContest(contestId);
+    public void validateCurrentContest(final Contest contest) {
         if (contest.getIsCurrent()) {
             throw new ContestException(CANNOT_UPDATE_TEAM_INFO_FOR_CURRENT);
         }
@@ -31,5 +30,11 @@ public class ContestConvenience {
 
     public Contest get6thContest() {
         return contestRepository.findByIsCurrentTrue().orElseThrow(() -> new ContestException(NOT_FOUND_CONTEST));
+    }
+
+    public void validateDuplicateContestName(String contestName) {
+        if (contestRepository.existsByContestName(contestName)) {
+            throw new ContestException(CONTEST_NAME_ALREADY_EXIST);
+        }
     }
 }

--- a/src/main/java/com/ops/ops/modules/contest/application/convenience/ContestConvenience.java
+++ b/src/main/java/com/ops/ops/modules/contest/application/convenience/ContestConvenience.java
@@ -1,9 +1,11 @@
 package com.ops.ops.modules.contest.application.convenience;
 
+import static com.ops.ops.modules.contest.exception.ContestExceptionType.CANNOT_UPDATE_TEAM_INFO_FOR_CURRENT;
+import static com.ops.ops.modules.contest.exception.ContestExceptionType.NOT_FOUND_CONTEST;
+
 import com.ops.ops.modules.contest.domain.Contest;
 import com.ops.ops.modules.contest.domain.dao.ContestRepository;
 import com.ops.ops.modules.contest.exception.ContestException;
-import com.ops.ops.modules.contest.exception.ContestExceptionType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,13 +19,17 @@ public class ContestConvenience {
 
     public Contest getValidateExistContest(final Long contestId) {
         return contestRepository.findById(contestId)
-                .orElseThrow(() -> new ContestException(ContestExceptionType.NOT_FOUND_CONTEST));
+                .orElseThrow(() -> new ContestException(NOT_FOUND_CONTEST));
     }
 
     public void validateNotCurrentContest(final Long contestId) {
         Contest contest = getValidateExistContest(contestId);
         if (contest.getIsCurrent()) {
-            throw new ContestException(ContestExceptionType.CANNOT_UPDATE_TEAM_INFO_FOR_CURRENT);
+            throw new ContestException(CANNOT_UPDATE_TEAM_INFO_FOR_CURRENT);
         }
+    }
+
+    public Contest get6thContest() {
+        return contestRepository.findByIsCurrentTrue().orElseThrow(() -> new ContestException(NOT_FOUND_CONTEST));
     }
 }

--- a/src/main/java/com/ops/ops/modules/contest/application/convenience/ContestConvenience.java
+++ b/src/main/java/com/ops/ops/modules/contest/application/convenience/ContestConvenience.java
@@ -32,7 +32,7 @@ public class ContestConvenience {
         return contestRepository.findByIsCurrentTrue().orElseThrow(() -> new ContestException(NOT_FOUND_CONTEST));
     }
 
-    public void validateDuplicateContestName(String contestName) {
+    public void checkDuplicateContestName(String contestName) {
         if (contestRepository.existsByContestName(contestName)) {
             throw new ContestException(CONTEST_NAME_ALREADY_EXIST);
         }

--- a/src/main/java/com/ops/ops/modules/file/domain/dao/FileRepository.java
+++ b/src/main/java/com/ops/ops/modules/file/domain/dao/FileRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FileRepository extends JpaRepository<File, Long> {
     List<File> findAllByTeamIdAndType(Long teamId, FileImageType type);
-    List<File> findAllByTeamId(final Long teamId);
     Optional<File> findByTeamIdAndType(Long teamId, FileImageType type);
     long countByTeamIdAndType(Long teamId, FileImageType type);
 }

--- a/src/main/java/com/ops/ops/modules/file/domain/dao/FileRepository.java
+++ b/src/main/java/com/ops/ops/modules/file/domain/dao/FileRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FileRepository extends JpaRepository<File, Long> {
     List<File> findAllByTeamIdAndType(Long teamId, FileImageType type);
+
     Optional<File> findByTeamIdAndType(Long teamId, FileImageType type);
+    
     long countByTeamIdAndType(Long teamId, FileImageType type);
 }

--- a/src/main/java/com/ops/ops/modules/file/exception/FileExceptionType.java
+++ b/src/main/java/com/ops/ops/modules/file/exception/FileExceptionType.java
@@ -4,7 +4,6 @@ import com.ops.ops.global.base.BaseExceptionType;
 import org.springframework.http.HttpStatus;
 
 public enum FileExceptionType implements BaseExceptionType {
-    NO_IMAGE(HttpStatus.BAD_REQUEST, "요청에 이미지가 없습니다"),
     NOT_EXISTS_MATCHING_IMAGE_ID(HttpStatus.NOT_FOUND, "아이디와 일치하는 이미지가 없습니다"),
     NOT_EXISTS_THUMBNAIL(HttpStatus.NOT_FOUND, "팀 썸네일이 존재하지 않습니다"),
     REQUEST_NOT_OWN_IMAGE(HttpStatus.BAD_REQUEST, "자신의 것이 아닌 이미지를 요청하였습니다."),

--- a/src/main/java/com/ops/ops/modules/member/application/MemberCommandService.java
+++ b/src/main/java/com/ops/ops/modules/member/application/MemberCommandService.java
@@ -135,8 +135,8 @@ public class MemberCommandService {
             final GoogleUser googleUser = googleOauth.getUserInfoByCode(code, GoogleUser.class);
 
             return memberRepository.findByEmail(googleUser.email())
-                .map(this::processExistingMemberLogin) // 기존 회원 로그인 처리
-                .orElseGet(() -> processNewMemberSignUp(googleUser)); // 새로운 회원 가입 처리
+                    .map(this::processExistingMemberLogin) // 기존 회원 로그인 처리
+                    .orElseGet(() -> processNewMemberSignUp(googleUser)); // 새로운 회원 가입 처리
 
         } catch (JsonProcessingException e) {
             log.error("구글 사용자 정보 파싱 실패: {}", e.getMessage());
@@ -149,8 +149,8 @@ public class MemberCommandService {
 
     private SignInResponse processExistingMemberLogin(final Member member) {
         final List<String> roles = member.getRoles().stream()
-            .map(MemberRoleType::toString)
-            .toList();
+                .map(MemberRoleType::toString)
+                .toList();
         final String token = jwtProvider.createToken(String.valueOf(member.getId()), roles, member.getName());
 
         return SignInResponse.from(member, token);
@@ -172,12 +172,12 @@ public class MemberCommandService {
         final String uniqueStudentId = "fake_" + UUID.randomUUID().toString().replace("-", "").substring(0, 10);
 
         return memberRepository.save(Member.builder()
-            .name(name)
-            .studentId(uniqueStudentId)
-            .email(email)
-            .password(randomPassword)
-            .roles(Set.of(ROLE_회원))
-            .build());
+                .name(name)
+                .studentId(uniqueStudentId)
+                .email(email)
+                .password(randomPassword)
+                .roles(Set.of(ROLE_회원))
+                .build());
     }
 
     private String generateRandomPassword() {

--- a/src/main/java/com/ops/ops/modules/member/application/MemberQueryService.java
+++ b/src/main/java/com/ops/ops/modules/member/application/MemberQueryService.java
@@ -10,8 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -27,10 +25,5 @@ public class MemberQueryService {
     private Member getValidateMember(final String studentId) {
         return memberRepository.findByStudentId(studentId).orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
     }
-
-    public List<String> getMemberNamesByIds(List<Long> memberIds) {
-        return memberRepository.findAllById(memberIds).stream()
-                .map(Member::getName)
-                .toList();
-    }
+    
 }

--- a/src/main/java/com/ops/ops/modules/member/application/MemberQueryService.java
+++ b/src/main/java/com/ops/ops/modules/member/application/MemberQueryService.java
@@ -1,11 +1,8 @@
 package com.ops.ops.modules.member.application;
 
-import static com.ops.ops.modules.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
-
+import com.ops.ops.modules.member.application.convenience.MemberConvenience;
 import com.ops.ops.modules.member.application.dto.response.EmailFindResponse;
 import com.ops.ops.modules.member.domain.Member;
-import com.ops.ops.modules.member.domain.dao.MemberRepository;
-import com.ops.ops.modules.member.exception.MemberException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,15 +12,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class MemberQueryService {
 
-    private final MemberRepository memberRepository;
+    private final MemberConvenience memberConvenience;
 
     public EmailFindResponse getMyEmail(final String studentId) {
-        final Member member = getValidateMember(studentId);
+        final Member member = memberConvenience.getValidateExistMemberByStudentId(studentId);
         return new EmailFindResponse(member.getEmail());
     }
 
-    private Member getValidateMember(final String studentId) {
-        return memberRepository.findByStudentId(studentId).orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
-    }
-    
 }

--- a/src/main/java/com/ops/ops/modules/member/application/convenience/MemberConvenience.java
+++ b/src/main/java/com/ops/ops/modules/member/application/convenience/MemberConvenience.java
@@ -1,8 +1,14 @@
 package com.ops.ops.modules.member.application.convenience;
 
+import static com.ops.ops.modules.member.exception.EmailAuthExceptionType.NOT_PUSAN_UNIVERSITY_EMAIL;
+import static com.ops.ops.modules.member.exception.MemberExceptionType.ALREADY_EXIST_EMAIL;
+import static com.ops.ops.modules.member.exception.MemberExceptionType.ALREADY_EXIST_STUDENT_ID;
+import static com.ops.ops.modules.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
+
 import com.ops.ops.modules.member.domain.Member;
 import com.ops.ops.modules.member.domain.MemberRoleType;
 import com.ops.ops.modules.member.domain.dao.MemberRepository;
+import com.ops.ops.modules.member.exception.EmailAuthException;
 import com.ops.ops.modules.member.exception.MemberException;
 import com.ops.ops.modules.member.exception.MemberExceptionType;
 import java.util.Set;
@@ -21,6 +27,36 @@ public class MemberConvenience {
     public Member getValidateExistMember(final Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberExceptionType.NOT_FOUND_MEMBER));
+    }
+
+    public Member getValidateExistMemberByStudentId(final String studentId) {
+        return memberRepository.findByStudentId(studentId).orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
+    }
+
+    public void validateExistMemberByEmail(final String email) {
+        memberRepository.findByEmail(email).orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
+    }
+
+    public Member getValidateExistMemberByEmail(final String email) {
+        return memberRepository.findByEmail(email).orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
+    }
+
+    public void validatePusanDomain(final String email) {
+        if (!email.endsWith("@pusan.ac.kr")) {
+            throw new EmailAuthException(NOT_PUSAN_UNIVERSITY_EMAIL);
+        }
+    }
+
+    public void checkIsDuplicateEmail(final String email) {
+        if (memberRepository.existsByEmail(email)) {
+            throw new MemberException(ALREADY_EXIST_EMAIL);
+        }
+    }
+
+    public void checkIsDuplicateStudentId(final String studentId) {
+        if (memberRepository.existsByStudentId(studentId)) {
+            throw new MemberException(ALREADY_EXIST_STUDENT_ID);
+        }
     }
 
     public Member createFakeMember(final String name, final Set<MemberRoleType> roles) {

--- a/src/main/java/com/ops/ops/modules/member/application/convenience/MemberConvenience.java
+++ b/src/main/java/com/ops/ops/modules/member/application/convenience/MemberConvenience.java
@@ -10,7 +10,6 @@ import com.ops.ops.modules.member.domain.MemberRoleType;
 import com.ops.ops.modules.member.domain.dao.MemberRepository;
 import com.ops.ops.modules.member.exception.EmailAuthException;
 import com.ops.ops.modules.member.exception.MemberException;
-import com.ops.ops.modules.member.exception.MemberExceptionType;
 import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +25,7 @@ public class MemberConvenience {
 
     public Member getValidateExistMember(final Long memberId) {
         return memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberException(MemberExceptionType.NOT_FOUND_MEMBER));
+                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
     }
 
     public Member getValidateExistMemberByStudentId(final String studentId) {

--- a/src/main/java/com/ops/ops/modules/member/application/convenience/MemberConvenience.java
+++ b/src/main/java/com/ops/ops/modules/member/application/convenience/MemberConvenience.java
@@ -61,13 +61,13 @@ public class MemberConvenience {
 
     public Member createFakeMember(final String name, final Set<MemberRoleType> roles) {
         final String unique = UUID.randomUUID().toString().replace("-", "").substring(0, 10);
-        return Member.builder()
+        return memberRepository.save(Member.builder()
                 .name(name)
                 .studentId("fake_" + unique)
                 .email("fake_" + unique + "@placeholder.com")
                 .password("!FAKE_USER!")
                 .roles(roles)
-                .build();
+                .build());
     }
 
     public long countTotalMember() {
@@ -76,5 +76,13 @@ public class MemberConvenience {
 
     public List<Member> findAllById(final List<Long> memberIds) {
         return memberRepository.findAllById(memberIds);
+    }
+
+    public void findById(final Long memberId) {
+         memberRepository.findById(memberId).orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
+    }
+
+    public void deleteMember(final Member member) {
+        memberRepository.delete(member);
     }
 }

--- a/src/main/java/com/ops/ops/modules/member/application/convenience/MemberConvenience.java
+++ b/src/main/java/com/ops/ops/modules/member/application/convenience/MemberConvenience.java
@@ -10,6 +10,7 @@ import com.ops.ops.modules.member.domain.MemberRoleType;
 import com.ops.ops.modules.member.domain.dao.MemberRepository;
 import com.ops.ops.modules.member.exception.EmailAuthException;
 import com.ops.ops.modules.member.exception.MemberException;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -71,5 +72,9 @@ public class MemberConvenience {
 
     public long countTotalMember() {
         return memberRepository.count();
+    }
+
+    public List<Member> findAllById(final List<Long> memberIds) {
+        return memberRepository.findAllById(memberIds);
     }
 }

--- a/src/main/java/com/ops/ops/modules/member/application/convenience/MemberConvenience.java
+++ b/src/main/java/com/ops/ops/modules/member/application/convenience/MemberConvenience.java
@@ -68,4 +68,8 @@ public class MemberConvenience {
                 .roles(roles)
                 .build();
     }
+
+    public long countTotalMember() {
+        return memberRepository.count();
+    }
 }

--- a/src/main/java/com/ops/ops/modules/member/domain/dao/EmailAuthRepository.java
+++ b/src/main/java/com/ops/ops/modules/member/domain/dao/EmailAuthRepository.java
@@ -4,7 +4,6 @@ import com.ops.ops.modules.member.domain.EmailAuth;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EmailAuthRepository extends JpaRepository<EmailAuth, Long> {
-
     EmailAuth findByEmail(final String email);
 
     boolean existsByEmail(final String email);

--- a/src/main/java/com/ops/ops/modules/member/domain/dao/MemberRepository.java
+++ b/src/main/java/com/ops/ops/modules/member/domain/dao/MemberRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-
     Optional<Member> findByEmail(final String email);
 
     Optional<Member> findByStudentId(final String studentId);

--- a/src/main/java/com/ops/ops/modules/notice/domain/dao/NoticeRepository.java
+++ b/src/main/java/com/ops/ops/modules/notice/domain/dao/NoticeRepository.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
-
     List<Notice> findAllByOrderByCreatedAtDesc();
 
 }

--- a/src/main/java/com/ops/ops/modules/team/api/TeamAdminController.java
+++ b/src/main/java/com/ops/ops/modules/team/api/TeamAdminController.java
@@ -1,23 +1,19 @@
 package com.ops.ops.modules.team.api;
 
-import com.ops.ops.global.security.annotation.LoginMember;
-import com.ops.ops.modules.member.domain.Member;
 import com.ops.ops.modules.team.application.TeamAdminQueryService;
 import com.ops.ops.modules.team.application.dto.response.TeamLikeRankingResponse;
 import com.ops.ops.modules.team.application.dto.response.TeamSubmissionStatusResponse;
 import com.ops.ops.modules.team.application.dto.response.TeamVoteRateResponse;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Team Admin", description = "팀 관리 기능 (관리자 전용)")
 @RestController
@@ -31,21 +27,21 @@ public class TeamAdminController {
 	@Operation(summary = "전체 팀 등록 현황 조회", description = "관리자가 모든 팀의 제출 여부를 포함한 현황을 조회합니다.")
 	@ApiResponse(responseCode = "200", description = "조회 성공")
 	@GetMapping("/dashboard")
-	public ResponseEntity<List<TeamSubmissionStatusResponse>> getAllTeamSubmissions(@LoginMember Member member) {
+	public ResponseEntity<List<TeamSubmissionStatusResponse>> getAllTeamSubmissions() {
 		return ResponseEntity.ok(teamAdminQueryService.getAllTeamSubmissions());
 	}
 
 	@Operation(summary = "좋아요 랭킹 조회", description = "좋아요 수 기준으로 팀 랭킹을 조회합니다. (Competition Ranking 방식)")
 	@ApiResponse(responseCode = "200", description = "조회 성공")
 	@GetMapping("/ranking")
-	public ResponseEntity<List<TeamLikeRankingResponse>> getTeamLikeRanking(@LoginMember Member member) {
+	public ResponseEntity<List<TeamLikeRankingResponse>> getTeamLikeRanking() {
 		return ResponseEntity.ok(teamAdminQueryService.getTeamLikeRanking());
 	}
 
 	@Operation(summary = "투표 참여율 조회", description = "전체 팀의 좋아요 수를 기반으로 투표 참여율을 계산하여 반환합니다.")
 	@ApiResponse(responseCode = "200", description = "조회 성공")
 	@GetMapping("/participation-rate")
-	public ResponseEntity<TeamVoteRateResponse> getTeamParticipationRate(@LoginMember Member member) {
+	public ResponseEntity<TeamVoteRateResponse> getTeamParticipationRate() {
 		return ResponseEntity.ok(teamAdminQueryService.getVoteRate());
 	}
 }

--- a/src/main/java/com/ops/ops/modules/team/api/TeamController.java
+++ b/src/main/java/com/ops/ops/modules/team/api/TeamController.java
@@ -43,6 +43,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/teams")
+@Validated
 public class TeamController {
     private final TeamQueryService teamQueryService;
     private final TeamCommandService teamCommandService;
@@ -127,7 +128,7 @@ public class TeamController {
     @Secured("ROLE_팀장")
     @DeleteMapping("/{teamId}/image")
     public ResponseEntity<Void> deletePreviewImage(@PathVariable Long teamId,
-                                                   @RequestBody PreviewDeleteRequest previewDeleteRequest) {
+                                                   @RequestBody @Valid PreviewDeleteRequest previewDeleteRequest) {
         teamCommandService.deletePreviewImages(teamId, previewDeleteRequest.imageIds(), PREVIEW);
         return ResponseEntity.noContent().build();
     }
@@ -161,7 +162,7 @@ public class TeamController {
     @PostMapping
     @Secured("ROLE_관리자")
     public ResponseEntity<TeamCreateResponse> createTeam(
-            @RequestBody @Validated TeamCreateRequest request
+            @RequestBody @Valid TeamCreateRequest request
     ) {
         TeamCreateResponse response = teamCommandService.createTeam(request);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/ops/ops/modules/team/api/TeamLikeController.java
+++ b/src/main/java/com/ops/ops/modules/team/api/TeamLikeController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
@@ -28,17 +29,14 @@ public class TeamLikeController {
 
     @Operation(summary = "좋아요 토글", description = "특정 팀에 대해 좋아요를 등록하거나 취소합니다.")
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "좋아요 상태 변경 성공"),
-        @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
-        @ApiResponse(responseCode = "404", description = "존재하지 않는 팀 ID")
+            @ApiResponse(responseCode = "200", description = "좋아요 상태 변경 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 팀 ID")
     })
     @PatchMapping("/{teamId}/like")
-    public ResponseEntity<TeamLikeToggleResponse> toggleLike(
-            @PathVariable Long teamId,
-            @RequestBody TeamLikeToggleRequest request,
-            @LoginMember Member member) {
-        TeamLikeToggleResponse response =
-                teamLikeService.toggleLike(member.getId(), teamId, request.isLiked());
-        return ResponseEntity.ok(response);
+    public ResponseEntity<TeamLikeToggleResponse> toggleLike(@PathVariable Long teamId,
+                                                             @RequestBody @Valid TeamLikeToggleRequest request,
+                                                             @LoginMember Member member) {
+        return ResponseEntity.ok(teamLikeService.toggleLike(member.getId(), teamId, request.isLiked()));
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/api/TeamMemberController.java
+++ b/src/main/java/com/ops/ops/modules/team/api/TeamMemberController.java
@@ -1,5 +1,7 @@
 package com.ops.ops.modules.team.api;
 
+import static org.springframework.http.HttpStatus.CREATED;
+
 import com.ops.ops.modules.team.application.TeamMemberCommandService;
 import com.ops.ops.modules.team.application.dto.request.TeamMemberCreateRequest;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,7 +10,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -35,7 +36,7 @@ public class TeamMemberController {
             @Valid @RequestBody final TeamMemberCreateRequest request
     ) {
         teamMemberCommandService.createTeamMember(teamId, request.teamMemberName());
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return ResponseEntity.status(CREATED).build();
     }
 
     @Operation(summary = "팀원 삭제", description = "특정 팀의 팀원을 삭제합니다. (소프트 삭제)")

--- a/src/main/java/com/ops/ops/modules/team/application/TeamAdminQueryService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamAdminQueryService.java
@@ -1,19 +1,16 @@
 package com.ops.ops.modules.team.application;
 
+import com.ops.ops.modules.contest.application.convenience.ContestConvenience;
 import com.ops.ops.modules.contest.domain.Contest;
-import com.ops.ops.modules.contest.domain.dao.ContestRepository;
-import com.ops.ops.modules.contest.exception.ContestException;
-import com.ops.ops.modules.contest.exception.ContestExceptionType;
-import com.ops.ops.modules.member.domain.dao.MemberRepository;
+import com.ops.ops.modules.member.application.convenience.MemberConvenience;
 import com.ops.ops.modules.team.application.dto.TeamLikeCountDto;
 import com.ops.ops.modules.team.application.dto.TeamRank;
 import com.ops.ops.modules.team.application.dto.response.TeamLikeRankingResponse;
+import com.ops.ops.modules.team.application.dto.response.TeamSubmissionStatusResponse;
 import com.ops.ops.modules.team.application.dto.response.TeamVoteRateResponse;
 import com.ops.ops.modules.team.domain.Team;
 import com.ops.ops.modules.team.domain.dao.TeamLikeRepository;
 import com.ops.ops.modules.team.domain.dao.TeamRepository;
-import com.ops.ops.modules.team.application.dto.response.TeamSubmissionStatusResponse;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -30,12 +27,12 @@ public class TeamAdminQueryService {
 
 	private final TeamRepository teamRepository;
 	private final TeamLikeRepository teamLikeRepository;
-	private final MemberRepository memberRepository;
-	private final ContestRepository contestRepository;
+
+	private final MemberConvenience memberConvenience;
+	private final ContestConvenience contestConvenience;
 
 	public List<TeamSubmissionStatusResponse> getAllTeamSubmissions() {
-		Contest currentContest = contestRepository.findByIsCurrentTrue()
-			.orElseThrow(() -> new ContestException(ContestExceptionType.NOT_FOUND_CONTEST));
+		final Contest currentContest = contestConvenience.get6thContest();
 
 		return teamRepository.findByContestId(currentContest.getId())
 			.stream()
@@ -55,12 +52,11 @@ public class TeamAdminQueryService {
 	}
 
 	public TeamVoteRateResponse getVoteRate() {
-		Contest currentContest = contestRepository.findByIsCurrentTrue()
-			.orElseThrow(() -> new ContestException(ContestExceptionType.NOT_FOUND_CONTEST));
+		final Contest currentContest = contestConvenience.get6thContest();
 		
 		List<Team> currentTeams = teamRepository.findByContestId(currentContest.getId());
 		
-		long totalMemberCount = memberRepository.count();
+		long totalMemberCount = memberConvenience.countTotalMember();
 		long votedMemberCount = teamLikeRepository.countDistinctMemberIdsByIsLikedTrueAndTeams(currentTeams);
 		long totalVoteCount = teamLikeRepository.countByIsLikedTrueAndTeams(currentTeams);
 
@@ -73,8 +69,7 @@ public class TeamAdminQueryService {
 	}
 
 	private Map<Long, Integer> getTeamLikeCountMap() {
-		Contest currentContest = contestRepository.findByIsCurrentTrue()
-			.orElseThrow(() -> new ContestException(ContestExceptionType.NOT_FOUND_CONTEST));
+		final Contest currentContest = contestConvenience.get6thContest();
 		
 		List<Team> currentTeams = teamRepository.findByContestId(currentContest.getId());
 		List<TeamLikeCountDto> likedList = teamLikeRepository.findTeamLikeCountGroupedByTeams(currentTeams);
@@ -87,8 +82,7 @@ public class TeamAdminQueryService {
 	}
 
 	private List<TeamRank> getTeamRankList(Map<Long, Integer> teamLikeCountMap) {
-		Contest currentContest = contestRepository.findByIsCurrentTrue()
-			.orElseThrow(() -> new ContestException(ContestExceptionType.NOT_FOUND_CONTEST));
+		final Contest currentContest = contestConvenience.get6thContest();
 		
 		List<TeamRank> teamRankList = new ArrayList<>();
 		List<Team> teamList = teamRepository.findByContestId(currentContest.getId());

--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
@@ -92,13 +92,18 @@ public class TeamCommandService {
 
     public TeamCreateResponse createTeam(TeamCreateRequest request) {
         final Contest contest = contestConvenience.getValidateExistContest(request.contestId());
-        if (!contest.isTeamCreatable()) {
-            throw new ContestException(CANNOT_CREATE_TEAM_OF_CURRENT_CONTEST);
-        }
+        checkIsTeamCreatable(contest);
 
-        final Team team = Team.of(request.leaderName(), request.teamName(), request.projectName(), request.overview(),
-                request.productionPath(), request.githubPath(), request.youTubePath(), request.contestId());
-        teamRepository.save(team);
+        final Team team = teamRepository.save(Team.builder()
+                .leaderName(request.leaderName())
+                .teamName(request.teamName())
+                .projectName(request.projectName())
+                .overview(request.overview())
+                .productionPath(request.productionPath())
+                .githubPath(request.githubPath())
+                .youTubePath(request.youTubePath())
+                .contestId(contest.getId())
+                .build());
 
         teamMemberCommandService.assignFakeTeamMember(team, request.leaderName(), Set.of(ROLE_팀장));
 
@@ -151,6 +156,12 @@ public class TeamCommandService {
         if (team.isLeaderNameChanged(newLeaderName)) {
             teamMemberCommandService.removeFakeTeamMemberByName(team, team.getLeaderName());
             teamMemberCommandService.assignFakeTeamMember(team, newLeaderName, Set.of(ROLE_팀장));
+        }
+    }
+
+    private void checkIsTeamCreatable(final Contest contest) {
+        if (!contest.isTeamCreatable()) {
+            throw new ContestException(CANNOT_CREATE_TEAM_OF_CURRENT_CONTEST);
         }
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
@@ -1,18 +1,22 @@
 package com.ops.ops.modules.team.application;
 
+import static com.ops.ops.modules.contest.exception.ContestExceptionType.ADMIN_ONLY_FOR_PAST_CONTEST;
+import static com.ops.ops.modules.contest.exception.ContestExceptionType.CANNOT_CHANGE_CONTEST_FOR_CURRENT;
+import static com.ops.ops.modules.contest.exception.ContestExceptionType.CANNOT_CREATE_TEAM_OF_CURRENT_CONTEST;
+import static com.ops.ops.modules.contest.exception.ContestExceptionType.CANNOT_UPDATE_TEAM_INFO_FOR_CURRENT;
 import static com.ops.ops.modules.file.domain.FileImageType.PREVIEW;
 import static com.ops.ops.modules.file.exception.FileExceptionType.EXCEED_PREVIEW_LIMIT;
+import static com.ops.ops.modules.member.domain.MemberRoleType.ROLE_관리자;
+import static com.ops.ops.modules.member.domain.MemberRoleType.ROLE_팀장;
 
 import com.ops.ops.global.util.FileStorageUtil;
 import com.ops.ops.modules.contest.application.convenience.ContestConvenience;
 import com.ops.ops.modules.contest.domain.Contest;
 import com.ops.ops.modules.contest.exception.ContestException;
-import com.ops.ops.modules.contest.exception.ContestExceptionType;
 import com.ops.ops.modules.file.domain.FileImageType;
 import com.ops.ops.modules.file.domain.dao.FileRepository;
 import com.ops.ops.modules.file.exception.FileException;
 import com.ops.ops.modules.member.domain.Member;
-import com.ops.ops.modules.member.domain.MemberRoleType;
 import com.ops.ops.modules.team.application.convenience.TeamConvenience;
 import com.ops.ops.modules.team.application.dto.request.TeamCreateRequest;
 import com.ops.ops.modules.team.application.dto.request.TeamDetailUpdateRequest;
@@ -32,14 +36,17 @@ import org.springframework.web.multipart.MultipartFile;
 public class TeamCommandService {
 
     private final FileRepository fileRepository;
-    private final TeamRepository teamRepository;
     private final FileStorageUtil fileStorageUtil;
+
+    private final TeamRepository teamRepository;
+
     private final TeamMemberCommandService teamMemberCommandService;
+
     private final ContestConvenience contestConvenience;
     private final TeamConvenience teamConvenience;
 
     public void saveThumbnailImage(final Long teamId, final MultipartFile image, final FileImageType thumbnailType) {
-        validateExistTeam(teamId);
+        teamConvenience.validateExistTeam(teamId);
         fileRepository.findByTeamIdAndType(teamId, thumbnailType).ifPresent(existingFile -> {
             fileStorageUtil.deleteFile(existingFile.getId());
         });
@@ -47,50 +54,34 @@ public class TeamCommandService {
     }
 
     public void deleteThumbnailImage(Long teamId, FileImageType thumbnailType) {
-        validateAndGetTeamById(teamId);
+        teamConvenience.validateExistTeam(teamId);
         fileRepository.findByTeamIdAndType(teamId, thumbnailType).ifPresent(existingFile -> {
             fileStorageUtil.deleteFile(existingFile.getId());
         });
     }
 
     public void deletePreviewImages(Long teamId, List<Long> ids, FileImageType fileImageType) {
-        validateAndGetTeamById(teamId);
+        //todo : 파일 타입 확인 로직 필요
+        teamConvenience.validateExistTeam(teamId);
         ids.forEach(fileStorageUtil::deleteFile);
     }
 
     public void savePreviewImages(Long teamId, List<MultipartFile> images) {
-        validateExistTeam(teamId);
+        teamConvenience.validateExistTeam(teamId);
         checkPreviewLimit(teamId, images);
         for (MultipartFile image : images) {
             fileStorageUtil.storeFile(image, teamId, PREVIEW);
         }
     }
 
-    private void checkPreviewLimit(Long teamId, List<MultipartFile> images) {
-        long savedCount = fileRepository.countByTeamIdAndType(teamId, PREVIEW);
-        if (savedCount + images.size() > 5) {
-            throw new FileException(EXCEED_PREVIEW_LIMIT);
-        }
-    }
-
-    private void validateExistTeam(final Long teamId) {
-        teamConvenience.getValidateExistTeam(teamId);
-    }
-
-    public Team validateAndGetTeamById(final Long teamId) {
-        return teamConvenience.getValidateExistTeam(teamId);
-    }
-
     public void deleteTeam(final Long teamId) {
-        final Team team = validateAndGetTeamById(teamId);
-        teamRepository.delete(team);
+        teamRepository.delete(teamConvenience.getValidateExistTeam(teamId));
     }
 
     public void updateTeamDetail(final Long teamId, final Member member, final TeamDetailUpdateRequest request) {
-        final Team team = validateAndGetTeamById(teamId);
-
+        final Team team = teamConvenience.getValidateExistTeam(teamId);
         final Contest newContest = contestConvenience.getValidateExistContest(request.contestId());
-        validateTeamContestChange(team, newContest, member, request.teamName(), request.projectName(),
+        checkTeamContestChange(team, newContest, member, request.teamName(), request.projectName(),
                 request.leaderName());
 
         updateLeaderIfChanged(team, request.leaderName());
@@ -102,56 +93,64 @@ public class TeamCommandService {
     public TeamCreateResponse createTeam(TeamCreateRequest request) {
         final Contest contest = contestConvenience.getValidateExistContest(request.contestId());
         if (!contest.isTeamCreatable()) {
-            throw new ContestException(ContestExceptionType.CANNOT_CREATE_TEAM_OF_CURRENT_CONTEST);
+            throw new ContestException(CANNOT_CREATE_TEAM_OF_CURRENT_CONTEST);
         }
 
         final Team team = Team.of(request.leaderName(), request.teamName(), request.projectName(), request.overview(),
                 request.productionPath(), request.githubPath(), request.youTubePath(), request.contestId());
         teamRepository.save(team);
 
-        teamMemberCommandService.assignFakeTeamMember(team, request.leaderName(), Set.of(MemberRoleType.ROLE_팀장));
+        teamMemberCommandService.assignFakeTeamMember(team, request.leaderName(), Set.of(ROLE_팀장));
 
         return TeamCreateResponse.from(team);
     }
 
-    private void validateTeamContestChange(final Team team, final Contest newContest, final Member member,
-                                           final String newTeamName, final String newProjectName,
-                                           final String newLeaderName) {
+    private void checkPreviewLimit(Long teamId, List<MultipartFile> images) {
+        long savedCount = fileRepository.countByTeamIdAndType(teamId, PREVIEW);
+        if (savedCount + images.size() > 5) {
+            throw new FileException(EXCEED_PREVIEW_LIMIT);
+        }
+    }
+
+    private void checkTeamContestChange(final Team team, final Contest newContest, final Member member,
+                                        final String newTeamName, final String newProjectName,
+                                        final String newLeaderName) {
         final Contest oldContest = contestConvenience.getValidateExistContest(team.getContestId());
         if (oldContest.getIsCurrent()) {
-            validateCurrentContest(team, newContest, newTeamName, newProjectName, newLeaderName);
+            checkCurrentContest(team, newContest, newTeamName, newProjectName, newLeaderName);
         } else {
-            validatePastContest(newContest, member);
+            checkPastContest(newContest, member);
         }
     }
 
-    private void validateCurrentContest(final Team team, final Contest newContest, final String newTeamName,
-                                        final String newProjectName, final String newLeaderName) {
+    private void checkCurrentContest(final Team team, final Contest newContest, final String newTeamName,
+                                     final String newProjectName, final String newLeaderName) {
         if (team.isContestChanged(newContest.getId())) {
-            throw new ContestException(ContestExceptionType.CANNOT_CHANGE_CONTEST_FOR_CURRENT);
+            throw new ContestException(CANNOT_CHANGE_CONTEST_FOR_CURRENT);
         }
         if (team.isTeamInfoChanged(newTeamName, newProjectName, newLeaderName)) {
-            throw new ContestException(ContestExceptionType.CANNOT_UPDATE_TEAM_INFO_FOR_CURRENT);
+            throw new ContestException(CANNOT_UPDATE_TEAM_INFO_FOR_CURRENT);
         }
     }
 
-    private void validatePastContest(final Contest newContest, final Member member) {
+    private void checkPastContest(final Contest newContest, final Member member) {
         if (!isAdmin(member)) {
-            throw new ContestException(ContestExceptionType.ADMIN_ONLY_FOR_PAST_CONTEST);
+            throw new ContestException(ADMIN_ONLY_FOR_PAST_CONTEST);
         }
         if (newContest.getIsCurrent()) {
-            throw new ContestException(ContestExceptionType.CANNOT_CREATE_TEAM_OF_CURRENT_CONTEST);
+            throw new ContestException(CANNOT_CREATE_TEAM_OF_CURRENT_CONTEST);
         }
     }
 
     private boolean isAdmin(final Member member) {
-        return member != null && member.getRoles().contains(MemberRoleType.ROLE_관리자);
+        return member != null && member.getRoles().contains(ROLE_관리자);
     }
 
+    // 멤버 삭제와 등록 로직이 복잡하여 예외적으로 command service 의존 허용
     private void updateLeaderIfChanged(Team team, String newLeaderName) {
         if (team.isLeaderNameChanged(newLeaderName)) {
             teamMemberCommandService.removeFakeTeamMemberByName(team, team.getLeaderName());
-            teamMemberCommandService.assignFakeTeamMember(team, newLeaderName, Set.of(MemberRoleType.ROLE_팀장));
+            teamMemberCommandService.assignFakeTeamMember(team, newLeaderName, Set.of(ROLE_팀장));
         }
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommentCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommentCommandService.java
@@ -24,9 +24,12 @@ public class TeamCommentCommandService {
 
 	public void createComment(final Long teamId, final Long memberId, final String description) {
 		final Team team = teamConvenience.getValidateExistTeam(teamId);
-		final TeamComment comment = TeamComment.of(description, memberId, team);
 
-		teamCommentRepository.save(comment);
+		teamCommentRepository.save(TeamComment.builder()
+				.description(description)
+				.memberId(memberId)
+				.team(team)
+				.build());
 	}
 
 	public void updateComment(final Long teamId, final Long commentId, final Long memberId, final String newDescription) {

--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommentCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommentCommandService.java
@@ -1,11 +1,13 @@
 package com.ops.ops.modules.team.application;
 
+import static com.ops.ops.modules.team.exception.TeamCommentExceptionType.NOT_OWNER_COMMENT;
+
+import com.ops.ops.modules.team.application.convenience.TeamCommentConvenience;
+import com.ops.ops.modules.team.application.convenience.TeamConvenience;
 import com.ops.ops.modules.team.domain.Team;
 import com.ops.ops.modules.team.domain.TeamComment;
 import com.ops.ops.modules.team.domain.dao.TeamCommentRepository;
 import com.ops.ops.modules.team.exception.TeamCommentException;
-import com.ops.ops.modules.team.exception.TeamCommentExceptionType;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,43 +17,37 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class TeamCommentCommandService {
 
-	private final TeamCommandService teamCommandService;
 	private final TeamCommentRepository teamCommentRepository;
 
+	private final TeamConvenience teamConvenience;
+	private final TeamCommentConvenience teamCommentConvenience;
+
 	public void createComment(final Long teamId, final Long memberId, final String description) {
-		final Team team = teamCommandService.validateAndGetTeamById(teamId);
+		final Team team = teamConvenience.getValidateExistTeam(teamId);
 		final TeamComment comment = TeamComment.of(description, memberId, team);
 
 		teamCommentRepository.save(comment);
 	}
 
 	public void updateComment(final Long teamId, final Long commentId, final Long memberId, final String newDescription) {
-		teamCommandService.validateAndGetTeamById(teamId);
-		final TeamComment comment = validateAndGetCommentById(commentId);
-		validateCommentOwnership(comment, memberId);
+		teamConvenience.getValidateExistTeam(teamId);
+		final TeamComment comment = teamCommentConvenience.getValidateExistComment(commentId);
+		isMine(comment, memberId);
 
 		comment.updateDescription(newDescription);
 	}
 
 	public void deleteComment(final Long teamId, final Long commentId, final Long memberId) {
-		teamCommandService.validateAndGetTeamById(teamId);
-		final TeamComment comment = validateAndGetCommentById(commentId);
-		validateCommentOwnership(comment, memberId);
+		teamConvenience.validateExistTeam(teamId);
+		final TeamComment comment = teamCommentConvenience.getValidateExistComment(commentId);
+		isMine(comment, memberId);
 
 		teamCommentRepository.delete(comment);
 	}
 
-	private TeamComment validateAndGetCommentById(final Long commentId) {
-		return teamCommentRepository.findById(commentId)
-			.orElseThrow(() -> new TeamCommentException(TeamCommentExceptionType.NOT_FOUND_COMMENT));
-	}
-
-	private void validateCommentOwnership(
-		final TeamComment comment,
-		final Long memberId
-	) {
-		if (!comment.getMemberId().equals(memberId)) {
-			throw new TeamCommentException(TeamCommentExceptionType.NOT_OWNER_COMMENT);
+	private void isMine(final TeamComment comment, final Long memberId) {
+		if (!comment.isMine(memberId)) {
+			throw new TeamCommentException(NOT_OWNER_COMMENT);
 		}
 	}
 }

--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommentQueryService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommentQueryService.java
@@ -1,14 +1,16 @@
 package com.ops.ops.modules.team.application;
 
+import static java.util.stream.Collectors.toMap;
+
+import com.ops.ops.modules.member.application.convenience.MemberConvenience;
 import com.ops.ops.modules.member.domain.Member;
-import com.ops.ops.modules.member.domain.dao.MemberRepository;
+import com.ops.ops.modules.team.application.convenience.TeamConvenience;
 import com.ops.ops.modules.team.application.dto.response.TeamCommentResponse;
 import com.ops.ops.modules.team.domain.Team;
 import com.ops.ops.modules.team.domain.TeamComment;
 import com.ops.ops.modules.team.domain.dao.TeamCommentRepository;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,11 +21,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class TeamCommentQueryService {
 
     private final TeamCommentRepository teamCommentRepository;
-    private final TeamCommandService teamCommandService;
-    private final MemberRepository memberRepository;
+
+    private final MemberConvenience memberConvenience;
+    private final TeamConvenience teamConvenience;
 
     public List<TeamCommentResponse> getComments(final Long teamId) {
-        Team team = teamCommandService.validateAndGetTeamById(teamId);
+        Team team = teamConvenience.getValidateExistTeam(teamId);
         List<TeamComment> comments = teamCommentRepository.findAllByTeamIdOrderByIdDesc(team.getId());
 
         List<Long> memberIds = comments.stream()
@@ -31,8 +34,9 @@ public class TeamCommentQueryService {
                 .distinct()
                 .toList();
 
-        Map<Long, String> memberIdNameMap = memberRepository.findAllById(memberIds).stream()
-                .collect(Collectors.toMap(Member::getId, Member::getName));
+        Map<Long, String> memberIdNameMap = memberConvenience.findAllById(memberIds)
+                .stream()
+                .collect(toMap(Member::getId, Member::getName));
 
         return comments.stream()
                 .map(comment -> new TeamCommentResponse(

--- a/src/main/java/com/ops/ops/modules/team/application/TeamLikeCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamLikeCommandService.java
@@ -44,7 +44,10 @@ public class TeamLikeCommandService {
 	}
 
 	private void saveTeamLike(Long memberId, Team team, Boolean isLiked) {
-		TeamLike teamLike = TeamLike.of(memberId, team, isLiked);
-		teamLikeRepository.save(teamLike);
+		teamLikeRepository.save(TeamLike.builder()
+						.memberId(memberId)
+						.team(team)
+						.isLiked(isLiked)
+						.build());
 	}
 }

--- a/src/main/java/com/ops/ops/modules/team/application/TeamLikeCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamLikeCommandService.java
@@ -1,5 +1,6 @@
 package com.ops.ops.modules.team.application;
 
+import com.ops.ops.modules.team.application.convenience.TeamConvenience;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
@@ -18,10 +19,11 @@ import lombok.RequiredArgsConstructor;
 public class TeamLikeCommandService {
 
 	private final TeamLikeRepository teamLikeRepository;
-	private final TeamCommandService teamCommandService;
+
+	private final TeamConvenience teamConvenience;
 
 	public TeamLikeToggleResponse toggleLike(Long memberId, Long teamId, Boolean isLiked) {
-		Team team = teamCommandService.validateAndGetTeamById(teamId);
+		Team team = teamConvenience.getValidateExistTeam(teamId);
 
 		Optional<TeamLike> teamLikeOptional = teamLikeRepository.findByMemberIdAndTeam(memberId, team);
 		if (teamLikeOptional.isEmpty()) {
@@ -41,7 +43,7 @@ public class TeamLikeCommandService {
 		return new TeamLikeToggleResponse(team.getId(), isLiked, message);
 	}
 
-	public void saveTeamLike(Long memberId, Team team, Boolean isLiked) {
+	private void saveTeamLike(Long memberId, Team team, Boolean isLiked) {
 		TeamLike teamLike = TeamLike.of(memberId, team, isLiked);
 		teamLikeRepository.save(teamLike);
 	}

--- a/src/main/java/com/ops/ops/modules/team/application/TeamMemberCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamMemberCommandService.java
@@ -1,10 +1,12 @@
 package com.ops.ops.modules.team.application;
 
+import static com.ops.ops.modules.member.domain.MemberRoleType.ROLE_회원;
 import static com.ops.ops.modules.team.exception.TeamMemberExceptionType.DUPLICATED_MEMBER_NAME;
 import static com.ops.ops.modules.team.exception.TeamMemberExceptionType.NOT_FOUND_TEAM_MEMBER;
 import static java.util.stream.Collectors.toMap;
 
 import com.ops.ops.modules.contest.application.convenience.ContestConvenience;
+import com.ops.ops.modules.contest.domain.Contest;
 import com.ops.ops.modules.member.application.convenience.MemberConvenience;
 import com.ops.ops.modules.member.domain.Member;
 import com.ops.ops.modules.member.domain.MemberRoleType;
@@ -44,13 +46,15 @@ public class TeamMemberCommandService {
 
     public void createTeamMember(final Long teamId, final String newTeamMemberName) {
         final Team team = teamConvenience.getValidateExistTeam(teamId);
-        contestConvenience.validateNotCurrentContest(team.getContestId());
+        final Contest contest = contestConvenience.getValidateExistContest(team.getContestId());
+        contestConvenience.validateCurrentContest(contest);
         checkDuplicatedTeamMemberName(team, newTeamMemberName);
-        assignFakeTeamMember(team, newTeamMemberName, Set.of(MemberRoleType.ROLE_회원));
+        assignFakeTeamMember(team, newTeamMemberName, Set.of(ROLE_회원));
     }
 
     public void removeFakeTeamMemberByName(final Team team, final String teamMemberName) {
-        contestConvenience.validateNotCurrentContest(team.getContestId());
+        final Contest contest = contestConvenience.getValidateExistContest(team.getContestId());
+        contestConvenience.validateCurrentContest(contest);
         final TeamMember teamMember = findTeamMemberByName(team, teamMemberName);
         teamMemberRepository.delete(teamMember);
 

--- a/src/main/java/com/ops/ops/modules/team/application/TeamQueryService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamQueryService.java
@@ -20,6 +20,7 @@ import com.ops.ops.modules.member.application.convenience.MemberConvenience;
 import com.ops.ops.modules.member.domain.Member;
 import com.ops.ops.modules.member.exception.MemberException;
 import com.ops.ops.modules.team.application.convenience.TeamConvenience;
+import com.ops.ops.modules.team.application.convenience.TeamLikeConvenience;
 import com.ops.ops.modules.team.application.dto.response.TeamDetailResponse;
 import com.ops.ops.modules.team.application.dto.response.TeamMemberResponse;
 import com.ops.ops.modules.team.application.dto.response.TeamSubmissionStatusResponse;
@@ -32,10 +33,7 @@ import com.ops.ops.modules.team.domain.dao.TeamMemberRepository;
 import com.ops.ops.modules.team.domain.dao.TeamRepository;
 import com.ops.ops.modules.team.exception.TeamException;
 import com.ops.ops.modules.team.exception.TeamMemberException;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.antlr.v4.runtime.misc.Pair;
 import org.springframework.core.io.Resource;
@@ -57,6 +55,7 @@ public class TeamQueryService {
     private final ContestConvenience contestConvenience;
     private final MemberConvenience memberConvenience;
     private final TeamConvenience teamConvenience;
+    private final TeamLikeConvenience teamLikeConvenience;
 
     public TeamDetailResponse getTeamDetail(final Long teamId, final Member member) {
         final Team team = teamRepository.findById(teamId)
@@ -94,15 +93,7 @@ public class TeamQueryService {
     }
 
     public List<TeamSummaryResponse> getAllTeamSummaries(final List<Team> teams, final Member member) {
-        Collections.shuffle(teams);
-
-        final Map<Long, Boolean> likeMap =
-                (member != null) ? teamLikeRepository.findAllByMemberIdAndTeamIn(member.getId(), teams).stream()
-                        .collect(Collectors.toMap(tl -> tl.getTeam().getId(), TeamLike::getIsLiked))
-                        : Collections.emptyMap();
-
-        return teams.stream().map(team -> TeamSummaryResponse.from(team, likeMap.getOrDefault(team.getId(), false)))
-                .toList();
+        return teamLikeConvenience.getAllTeamSummaries(teams, member);
     }
 
     public TeamSubmissionStatusResponse getSubmissionStatus(final Member member) {

--- a/src/main/java/com/ops/ops/modules/team/application/TeamQueryService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamQueryService.java
@@ -24,7 +24,6 @@ import com.ops.ops.modules.team.application.convenience.TeamLikeConvenience;
 import com.ops.ops.modules.team.application.dto.response.TeamDetailResponse;
 import com.ops.ops.modules.team.application.dto.response.TeamMemberResponse;
 import com.ops.ops.modules.team.application.dto.response.TeamSubmissionStatusResponse;
-import com.ops.ops.modules.team.application.dto.response.TeamSummaryResponse;
 import com.ops.ops.modules.team.domain.Team;
 import com.ops.ops.modules.team.domain.TeamLike;
 import com.ops.ops.modules.team.domain.TeamMember;
@@ -90,10 +89,6 @@ public class TeamQueryService {
         final File findFile = fileRepository.findById(imageId).orElseThrow(() -> new FileException(NOT_EXISTS_PREVIEW));
         checkImageConverted(findFile);
         return fileStorageUtil.findFileAndType(findFile.getId());
-    }
-
-    public List<TeamSummaryResponse> getAllTeamSummaries(final List<Team> teams, final Member member) {
-        return teamLikeConvenience.getAllTeamSummaries(teams, member);
     }
 
     public TeamSubmissionStatusResponse getSubmissionStatus(final Member member) {

--- a/src/main/java/com/ops/ops/modules/team/application/TeamQueryService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamQueryService.java
@@ -7,7 +7,7 @@ import static com.ops.ops.modules.file.exception.FileExceptionType.NOT_WEBP_CONV
 import static com.ops.ops.modules.member.domain.MemberRoleType.ROLE_팀장;
 import static com.ops.ops.modules.member.exception.MemberExceptionType.NOT_FOUND_LEADER;
 import static com.ops.ops.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
-import static com.ops.ops.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM_MEMBER;
+import static com.ops.ops.modules.team.exception.TeamMemberExceptionType.NOT_FOUND_TEAM_MEMBER;
 
 import com.ops.ops.global.util.FileStorageUtil;
 import com.ops.ops.modules.contest.application.convenience.ContestConvenience;
@@ -31,6 +31,7 @@ import com.ops.ops.modules.team.domain.dao.TeamLikeRepository;
 import com.ops.ops.modules.team.domain.dao.TeamMemberRepository;
 import com.ops.ops.modules.team.domain.dao.TeamRepository;
 import com.ops.ops.modules.team.exception.TeamException;
+import com.ops.ops.modules.team.exception.TeamMemberException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -106,7 +107,7 @@ public class TeamQueryService {
 
     public TeamSubmissionStatusResponse getSubmissionStatus(final Member member) {
         TeamMember teamMember = teamMemberRepository.findByMemberId(member.getId())
-                .orElseThrow(() -> new TeamException(NOT_FOUND_TEAM_MEMBER));
+                .orElseThrow(() -> new TeamMemberException(NOT_FOUND_TEAM_MEMBER));
         Team team = teamMember.getTeam();
 
         return TeamSubmissionStatusResponse.fromEntity(team);

--- a/src/main/java/com/ops/ops/modules/team/application/TeamQueryService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamQueryService.java
@@ -151,9 +151,4 @@ public class TeamQueryService {
         return TeamSubmissionStatusResponse.fromEntity(team);
     }
 
-    private void validateOwnership(Long teamId, File previewFile) {
-        if (!previewFile.getTeamId().equals(teamId)) {
-            throw new FileException(FileExceptionType.REQUEST_NOT_OWN_IMAGE);
-        }
-    }
 }

--- a/src/main/java/com/ops/ops/modules/team/application/TeamQueryService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamQueryService.java
@@ -1,7 +1,13 @@
 package com.ops.ops.modules.team.application;
 
 import static com.ops.ops.modules.file.domain.FileImageType.THUMBNAIL;
+import static com.ops.ops.modules.file.exception.FileExceptionType.NOT_EXISTS_PREVIEW;
+import static com.ops.ops.modules.file.exception.FileExceptionType.NOT_EXISTS_THUMBNAIL;
+import static com.ops.ops.modules.file.exception.FileExceptionType.NOT_WEBP_CONVERTED;
+import static com.ops.ops.modules.member.domain.MemberRoleType.ROLE_팀장;
+import static com.ops.ops.modules.member.exception.MemberExceptionType.NOT_FOUND_LEADER;
 import static com.ops.ops.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
+import static com.ops.ops.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM_MEMBER;
 
 import com.ops.ops.global.util.FileStorageUtil;
 import com.ops.ops.modules.contest.application.convenience.ContestConvenience;
@@ -10,12 +16,10 @@ import com.ops.ops.modules.file.domain.File;
 import com.ops.ops.modules.file.domain.FileImageType;
 import com.ops.ops.modules.file.domain.dao.FileRepository;
 import com.ops.ops.modules.file.exception.FileException;
-import com.ops.ops.modules.file.exception.FileExceptionType;
+import com.ops.ops.modules.member.application.convenience.MemberConvenience;
 import com.ops.ops.modules.member.domain.Member;
-import com.ops.ops.modules.member.domain.MemberRoleType;
-import com.ops.ops.modules.member.domain.dao.MemberRepository;
 import com.ops.ops.modules.member.exception.MemberException;
-import com.ops.ops.modules.member.exception.MemberExceptionType;
+import com.ops.ops.modules.team.application.convenience.TeamConvenience;
 import com.ops.ops.modules.team.application.dto.response.TeamDetailResponse;
 import com.ops.ops.modules.team.application.dto.response.TeamMemberResponse;
 import com.ops.ops.modules.team.application.dto.response.TeamSubmissionStatusResponse;
@@ -27,7 +31,6 @@ import com.ops.ops.modules.team.domain.dao.TeamLikeRepository;
 import com.ops.ops.modules.team.domain.dao.TeamMemberRepository;
 import com.ops.ops.modules.team.domain.dao.TeamRepository;
 import com.ops.ops.modules.team.exception.TeamException;
-import com.ops.ops.modules.team.exception.TeamExceptionType;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -42,17 +45,21 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class TeamQueryService {
-    private final TeamRepository teamRepository;
+
     private final FileRepository fileRepository;
     private final FileStorageUtil fileStorageUtil;
-    private final MemberRepository memberRepository;
+
+    private final TeamRepository teamRepository;
     private final TeamLikeRepository teamLikeRepository;
     private final TeamMemberRepository teamMemberRepository;
+
     private final ContestConvenience contestConvenience;
+    private final MemberConvenience memberConvenience;
+    private final TeamConvenience teamConvenience;
 
     public TeamDetailResponse getTeamDetail(final Long teamId, final Member member) {
         final Team team = teamRepository.findById(teamId)
-                .orElseThrow(() -> new TeamException(TeamExceptionType.NOT_FOUND_TEAM));
+                .orElseThrow(() -> new TeamException(NOT_FOUND_TEAM));
 
         final Contest contest = contestConvenience.getValidateExistContest(team.getContestId());
 
@@ -64,13 +71,51 @@ public class TeamQueryService {
                 .map(File::getId)
                 .toList();
 
-        final boolean isLiked = (member != null)
-                ? teamLikeRepository.findByMemberIdAndTeam(member.getId(), team)
-                .map(TeamLike::getIsLiked)
-                .orElse(false)
-                : false;
+        final boolean isLiked = (member != null) ? teamLikeRepository.findByMemberIdAndTeam(member.getId(), team)
+                .map(TeamLike::getIsLiked).orElse(false) : false;
 
         return TeamDetailResponse.from(contest, team, leaderId, teamMembers, previewIds, isLiked);
+    }
+
+    public Pair<Resource, String> findThumbnailImage(final Long teamId) {
+        teamConvenience.validateExistTeam(teamId);
+        final File findFile = fileRepository.findByTeamIdAndType(teamId, THUMBNAIL)
+                .orElseThrow(() -> new FileException(NOT_EXISTS_THUMBNAIL));
+        checkImageConverted(findFile);
+        return fileStorageUtil.findFileAndType(findFile.getId());
+    }
+
+    public Pair<Resource, String> findPreviewImage(Long teamId, Long imageId) {
+        teamConvenience.validateExistTeam(teamId);
+        final File findFile = fileRepository.findById(imageId).orElseThrow(() -> new FileException(NOT_EXISTS_PREVIEW));
+        checkImageConverted(findFile);
+        return fileStorageUtil.findFileAndType(findFile.getId());
+    }
+
+    public List<TeamSummaryResponse> getAllTeamSummaries(final List<Team> teams, final Member member) {
+        Collections.shuffle(teams);
+
+        final Map<Long, Boolean> likeMap =
+                (member != null) ? teamLikeRepository.findAllByMemberIdAndTeamIn(member.getId(), teams).stream()
+                        .collect(Collectors.toMap(tl -> tl.getTeam().getId(), TeamLike::getIsLiked))
+                        : Collections.emptyMap();
+
+        return teams.stream().map(team -> TeamSummaryResponse.from(team, likeMap.getOrDefault(team.getId(), false)))
+                .toList();
+    }
+
+    public TeamSubmissionStatusResponse getSubmissionStatus(final Member member) {
+        TeamMember teamMember = teamMemberRepository.findByMemberId(member.getId())
+                .orElseThrow(() -> new TeamException(NOT_FOUND_TEAM_MEMBER));
+        Team team = teamMember.getTeam();
+
+        return TeamSubmissionStatusResponse.fromEntity(team);
+    }
+
+    private void checkImageConverted(File findFile) {
+        if (!findFile.isWebpConverted()) {
+            throw new FileException(NOT_WEBP_CONVERTED);
+        }
     }
 
     private Long getLeaderIdByTeamId(final Long teamId) {
@@ -90,65 +135,20 @@ public class TeamQueryService {
         if (memberIds.isEmpty()) {
             return List.of();
         }
-        return memberRepository.findAllById(memberIds).stream()
+        return memberConvenience.findAllById(memberIds)
+                .stream()
                 .filter(member -> !member.isTeamLeader())
                 .map(member -> new TeamMemberResponse(member.getId(), member.getName()))
                 .toList();
     }
 
     private Long getLeaderIdByIds(List<Long> memberIds) {
-        return memberRepository.findAllById(memberIds).stream()
-                .filter(member -> member.getRoles().contains(MemberRoleType.ROLE_팀장))
+        return memberConvenience.findAllById(memberIds)
+                .stream()
+                .filter(member -> member.getRoles().contains(ROLE_팀장))
                 .findFirst()
                 .map(Member::getId)
-                .orElseThrow(() -> new MemberException(MemberExceptionType.NOT_FOUND_LEADER));
-    }
-
-    public Pair<Resource, String> findThumbnailImage(final Long teamId) {
-        validateAndGetTeamById(teamId);
-        final File findFile = fileRepository.findByTeamIdAndType(teamId, THUMBNAIL).orElseThrow(() -> new FileException(
-                FileExceptionType.NOT_EXISTS_THUMBNAIL));
-        checkImageConverted(findFile);
-        return fileStorageUtil.findFileAndType(findFile.getId());
-    }
-
-    public Pair<Resource, String> findPreviewImage(Long teamId, Long imageId) {
-        validateAndGetTeamById(teamId);
-        final File findFile = fileRepository.findById(imageId).orElseThrow(() -> new FileException(
-                FileExceptionType.NOT_EXISTS_PREVIEW));
-        checkImageConverted(findFile);
-        return fileStorageUtil.findFileAndType(findFile.getId());
-    }
-
-    private void checkImageConverted(File findFile) {
-        if (!findFile.isWebpConverted()) {
-            throw new FileException(FileExceptionType.NOT_WEBP_CONVERTED);
-        }
-    }
-
-    public Team validateAndGetTeamById(final Long teamId) {
-        return teamRepository.findById(teamId)
-                .orElseThrow(() -> new TeamException(NOT_FOUND_TEAM));
-    }
-
-    public List<TeamSummaryResponse> getAllTeamSummaries(final List<Team> teams, final Member member) {
-        Collections.shuffle(teams);
-
-        final Map<Long, Boolean> likeMap =
-                (member != null) ? teamLikeRepository.findAllByMemberIdAndTeamIn(member.getId(), teams).stream()
-                        .collect(Collectors.toMap(tl -> tl.getTeam().getId(), TeamLike::getIsLiked))
-                        : Collections.emptyMap();
-
-        return teams.stream().map(team -> TeamSummaryResponse.from(team, likeMap.getOrDefault(team.getId(), false)))
-                .toList();
-    }
-
-    public TeamSubmissionStatusResponse getSubmissionStatus(final Member member) {
-        TeamMember teamMember = teamMemberRepository.findByMemberId(member.getId())
-                .orElseThrow(() -> new TeamException(TeamExceptionType.NOT_FOUND_TEAM_MEMBER));
-        Team team = teamMember.getTeam();
-
-        return TeamSubmissionStatusResponse.fromEntity(team);
+                .orElseThrow(() -> new MemberException(NOT_FOUND_LEADER));
     }
 
 }

--- a/src/main/java/com/ops/ops/modules/team/application/convenience/TeamCommentConvenience.java
+++ b/src/main/java/com/ops/ops/modules/team/application/convenience/TeamCommentConvenience.java
@@ -1,0 +1,22 @@
+package com.ops.ops.modules.team.application.convenience;
+
+import static com.ops.ops.modules.team.exception.TeamCommentExceptionType.NOT_FOUND_COMMENT;
+
+import com.ops.ops.modules.team.domain.TeamComment;
+import com.ops.ops.modules.team.domain.dao.TeamCommentRepository;
+import com.ops.ops.modules.team.exception.TeamCommentException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeamCommentConvenience {
+
+    private final TeamCommentRepository teamCommentRepository;
+
+    public TeamComment getValidateExistComment(final Long commentId) {
+        return teamCommentRepository.findById(commentId).orElseThrow(() -> new TeamCommentException(NOT_FOUND_COMMENT));
+    }
+}

--- a/src/main/java/com/ops/ops/modules/team/application/convenience/TeamConvenience.java
+++ b/src/main/java/com/ops/ops/modules/team/application/convenience/TeamConvenience.java
@@ -33,7 +33,7 @@ public class TeamConvenience {
     }
 
     public List<Team> findAllByContestId(final Long contestId) {
-        return teamRepository.findByContestId(contestId);
+        return teamRepository.findAllByContestId(contestId);
     }
 
 }

--- a/src/main/java/com/ops/ops/modules/team/application/convenience/TeamConvenience.java
+++ b/src/main/java/com/ops/ops/modules/team/application/convenience/TeamConvenience.java
@@ -1,9 +1,10 @@
 package com.ops.ops.modules.team.application.convenience;
 
+import static com.ops.ops.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
+
 import com.ops.ops.modules.team.domain.Team;
 import com.ops.ops.modules.team.domain.dao.TeamRepository;
 import com.ops.ops.modules.team.exception.TeamException;
-import com.ops.ops.modules.team.exception.TeamExceptionType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,7 +16,10 @@ public class TeamConvenience {
     private final TeamRepository teamRepository;
 
     public Team getValidateExistTeam(Long teamId) {
-        return teamRepository.findById(teamId)
-                .orElseThrow(() -> new TeamException(TeamExceptionType.NOT_FOUND_TEAM));
+        return teamRepository.findById(teamId).orElseThrow(() -> new TeamException(NOT_FOUND_TEAM));
+    }
+
+    public void validateExistTeam(Long teamId) {
+        teamRepository.findById(teamId).orElseThrow(() -> new TeamException(NOT_FOUND_TEAM));
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/application/convenience/TeamConvenience.java
+++ b/src/main/java/com/ops/ops/modules/team/application/convenience/TeamConvenience.java
@@ -1,10 +1,13 @@
 package com.ops.ops.modules.team.application.convenience;
 
+import static com.ops.ops.modules.contest.exception.ContestExceptionType.CONTEST_HAS_TEAMS;
 import static com.ops.ops.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
 
+import com.ops.ops.modules.contest.exception.ContestException;
 import com.ops.ops.modules.team.domain.Team;
 import com.ops.ops.modules.team.domain.dao.TeamRepository;
 import com.ops.ops.modules.team.exception.TeamException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,4 +25,15 @@ public class TeamConvenience {
     public void validateExistTeam(Long teamId) {
         teamRepository.findById(teamId).orElseThrow(() -> new TeamException(NOT_FOUND_TEAM));
     }
+
+    public void checkAllContestDelete(final Long contestId) {
+        if (teamRepository.existsByContestId(contestId)) {
+            throw new ContestException(CONTEST_HAS_TEAMS);
+        }
+    }
+
+    public List<Team> findAllByContestId(final Long contestId) {
+        return teamRepository.findByContestId(contestId);
+    }
+
 }

--- a/src/main/java/com/ops/ops/modules/team/application/convenience/TeamLikeConvenience.java
+++ b/src/main/java/com/ops/ops/modules/team/application/convenience/TeamLikeConvenience.java
@@ -1,0 +1,35 @@
+package com.ops.ops.modules.team.application.convenience;
+
+import static java.util.stream.Collectors.toMap;
+
+import com.ops.ops.modules.member.domain.Member;
+import com.ops.ops.modules.team.application.dto.response.TeamSummaryResponse;
+import com.ops.ops.modules.team.domain.Team;
+import com.ops.ops.modules.team.domain.TeamLike;
+import com.ops.ops.modules.team.domain.dao.TeamLikeRepository;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeamLikeConvenience {
+
+    private final TeamLikeRepository teamLikeRepository;
+
+    public List<TeamSummaryResponse> getAllTeamSummaries(final List<Team> teams, final Member member) {
+        Collections.shuffle(teams);
+
+        final Map<Long, Boolean> likeMap =
+                (member != null) ? teamLikeRepository.findAllByMemberIdAndTeamIn(member.getId(), teams).stream()
+                        .collect(toMap(tl -> tl.getTeam().getId(), TeamLike::getIsLiked))
+                        : Collections.emptyMap();
+
+        return teams.stream().map(team -> TeamSummaryResponse.from(team, likeMap.getOrDefault(team.getId(), false)))
+                .toList();
+    }
+}

--- a/src/main/java/com/ops/ops/modules/team/application/convenience/TeamMemberConvenience.java
+++ b/src/main/java/com/ops/ops/modules/team/application/convenience/TeamMemberConvenience.java
@@ -1,0 +1,23 @@
+package com.ops.ops.modules.team.application.convenience;
+
+import static com.ops.ops.modules.team.exception.TeamMemberExceptionType.NOT_FOUND_TEAM_MEMBER;
+
+import com.ops.ops.modules.team.domain.Team;
+import com.ops.ops.modules.team.domain.dao.TeamMemberRepository;
+import com.ops.ops.modules.team.exception.TeamMemberException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeamMemberConvenience {
+
+    private final TeamMemberRepository teamMemberRepository;
+
+    public void validateMemberBelongsToTeam(final Team team, final Long memberId) {
+        teamMemberRepository.findByMemberIdAndTeam(memberId, team)
+                .orElseThrow(() -> new TeamMemberException(NOT_FOUND_TEAM_MEMBER));
+    }
+}

--- a/src/main/java/com/ops/ops/modules/team/domain/Team.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/Team.java
@@ -76,20 +76,6 @@ public class Team extends BaseEntity {
         this.contestId = contestId;
     }
 
-    public static Team of(String leaderName, String teamName, String projectName, String overview,
-                          String productionPath, String githubPath, String youTubePath, Long contestId) {
-        return Team.builder()
-                .leaderName(leaderName)
-                .teamName(teamName)
-                .projectName(projectName)
-                .overview(overview)
-                .productionPath(productionPath)
-                .githubPath(githubPath)
-                .youTubePath(youTubePath)
-                .contestId(contestId)
-                .build();
-    }
-
     public void updateDetail(final String newLeaderName, final String newTeamName, final String newProjectName,
                              final String newOverview, final String newProductionPath, final String newGithubPath,
                              final String newYouTubePath, final Long newContestId) {

--- a/src/main/java/com/ops/ops/modules/team/domain/Team.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/Team.java
@@ -22,7 +22,7 @@ import org.hibernate.annotations.SQLRestriction;
 @SQLRestriction("is_deleted = false")
 @SQLDelete(sql = "UPDATE team SET is_deleted = true where id = ?")
 public class Team extends BaseEntity {
-    // 이미지 관련 추가 필요
+    
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/ops/ops/modules/team/domain/TeamComment.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/TeamComment.java
@@ -59,4 +59,8 @@ public class TeamComment extends BaseEntity {
     public void updateDescription(final String newDescription) {
         this.description = newDescription;
     }
+
+    public boolean isMine(Long memberId) {
+        return this.memberId.equals(memberId);
+    }
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/TeamComment.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/TeamComment.java
@@ -48,14 +48,6 @@ public class TeamComment extends BaseEntity {
         this.isDeleted = false;
     }
 
-    public static TeamComment of(String description, Long memberId, Team team) {
-        return TeamComment.builder()
-            .description(description)
-            .memberId(memberId)
-            .team(team)
-            .build();
-    }
-
     public void updateDescription(final String newDescription) {
         this.description = newDescription;
     }

--- a/src/main/java/com/ops/ops/modules/team/domain/TeamLike.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/TeamLike.java
@@ -39,15 +39,7 @@ public class TeamLike extends BaseEntity {
         this.team = team;
         this.isLiked = isLiked;
     }
-
-    public static TeamLike of(Long memberId, Team team, boolean isLiked) {
-        return TeamLike.builder()
-            .memberId(memberId)
-            .team(team)
-            .isLiked(isLiked)
-            .build();
-    }
-
+    
     public void setLiked(boolean liked) {
         this.isLiked = liked;
     }

--- a/src/main/java/com/ops/ops/modules/team/domain/dao/TeamRepository.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/dao/TeamRepository.java
@@ -9,6 +9,8 @@ import java.util.List;
 @Repository
 public interface TeamRepository extends JpaRepository<Team, Long> {
     boolean existsByContestId(Long contestId);
+
     List<Team> findByContestId(Long contestId);
+
     List<Team> findAllByContestId(Long contestId);
 }

--- a/src/main/java/com/ops/ops/modules/team/exception/TeamMemberException.java
+++ b/src/main/java/com/ops/ops/modules/team/exception/TeamMemberException.java
@@ -1,0 +1,24 @@
+package com.ops.ops.modules.team.exception;
+
+import com.ops.ops.global.base.BaseException;
+import com.ops.ops.global.base.BaseExceptionType;
+
+public class TeamMemberException extends BaseException {
+
+    private final TeamMemberExceptionType exceptionType;
+
+    public TeamMemberException(final TeamMemberExceptionType exceptionType) {
+        super(exceptionType.errorMessage());
+        this.exceptionType = exceptionType;
+    }
+
+    public TeamMemberException(final TeamMemberExceptionType exceptionType, final String message) {
+        super(message);
+        this.exceptionType = exceptionType;
+    }
+
+    @Override
+    public BaseExceptionType exceptionType() {
+        return exceptionType;
+    }
+}

--- a/src/main/java/com/ops/ops/modules/team/exception/TeamMemberExceptionType.java
+++ b/src/main/java/com/ops/ops/modules/team/exception/TeamMemberExceptionType.java
@@ -3,15 +3,17 @@ package com.ops.ops.modules.team.exception;
 import com.ops.ops.global.base.BaseExceptionType;
 import org.springframework.http.HttpStatus;
 
-public enum TeamExceptionType implements BaseExceptionType {
-    NOT_FOUND_TEAM(HttpStatus.NOT_FOUND, "팀을 찾을 수 없습니다."),
-    NOT_TEAM_LEADER(HttpStatus.FORBIDDEN, "해당 팀의 팀장 권한이 없습니다."),
+public enum TeamMemberExceptionType implements BaseExceptionType {
+
+    NOT_FOUND_TEAM_MEMBER(HttpStatus.NOT_FOUND, "팀원을 찾을 수 없습니다."),
+    NOT_FOUND_TEAM_MEMBER_IN_TEAM(HttpStatus.NOT_FOUND, "해당 팀에 속해있지 않습니다."),
+    DUPLICATED_MEMBER_NAME(HttpStatus.CONFLICT, "팀 내에 동일한 이름을 가진 팀원이 있습니다."),
     ;
 
     private final HttpStatus httpStatus;
     private final String errorMessage;
 
-    TeamExceptionType(final HttpStatus httpStatus, final String errorMessage) {
+    TeamMemberExceptionType(final HttpStatus httpStatus, final String errorMessage) {
         this.httpStatus = httpStatus;
         this.errorMessage = errorMessage;
     }


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #86

## 📜 작업 내용
- 로직은 건들지 않고, 코드 스타일만 수정했습니다! 하지만 수정 중 의도치 않게 수정된 부분이 있을 수 있으므로 모두 확인 부탁드려용!

- 중복 코드, 사용하지 않는 코드 삭제
- 생성 로직 위치 변경
- 누락된 검증 추가
- import 추가
- 메서드 명 변경

- `command Service`와 `queryService`는 같은 모듈 내 `repository`만 의존합니다.
  - 다른 모듈의 `repository`가 필요하면 `convenience`를 사용하도록 수정
- `convenience`는 본인의 `repository`만 의존합니다.
  - 이를 통해 `command`와 `query` 서비스 간 의존을 없애 결합도를 낮추었습니다.
  -  모듈이 자신의 도메인 로직과 DB 스키마에 대한 책임만 갖고, 내부 구현(Repository 구조 등)을 외부에 노출하지 않도록 하였습니다.
  - 가짜 멤버 삭제 & 등록은 `convenience`로 빼기에는 너무 복잡해져서 예외적으로 그냥 두었습니다.
- `convenience`에는 **`validate` 코드, 중복 코드, 다른 모듈에서 필요로 하는 dao 접근 코드, 중복이 예상되는 코드**를 넣었습니다.
  - `command`와 `query` 서비스에는 `validate`라는 용어 대신 `check`를 사용하도록 변경했습니다.
  
- 이외의 코드는 코드로 확인 부탁드려요..! (적기에는 내용이 너무 많음)

## 💬 리뷰 요구사항

- 갈수록 힘들어서 뇌빼고 작업해서.. 꼼꼼히 확인 부탁드려요 🥲
- 궁금한 부분 `comment` 달아주세요!

## ✨ 기타

- mvp 언제 끝나나
