### PR TITLE
Refactor/#85 구글 소셜 로그인 - 프론트 개발 환경별 콜백 URL 동적 처리하기 

### DIFF
--- a/src/main/java/com/ops/ops/global/util/oauth/component/GoogleOauth.java
+++ b/src/main/java/com/ops/ops/global/util/oauth/component/GoogleOauth.java
@@ -80,15 +80,13 @@ public class GoogleOauth implements SocialOauth {
         try {
             ServletRequestAttributes attributes =
                     (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+
             if (attributes == null) {
-                log.info(
-                        "RequestAttributes가 null - 기본 콜백 URL 사용: {}",
-                        GOOGLE_SNS_CALLBACK_LOGIN_URL);
-                return GOOGLE_SNS_CALLBACK_LOGIN_URL;
+                log.error("OAuth 인증 요청이 HTTP 요청 컨텍스트 외부에서 호출됨");
+                throw new OAuthException(SOCIAL_LOGIN_SERVER_ERROR);
             }
 
             HttpServletRequest request = attributes.getRequest();
-
             String origin = request.getHeader("Origin");
             log.info("감지된 Origin 헤더: {}", origin);
 

--- a/src/main/java/com/ops/ops/global/util/oauth/component/GoogleOauth.java
+++ b/src/main/java/com/ops/ops/global/util/oauth/component/GoogleOauth.java
@@ -2,17 +2,16 @@ package com.ops.ops.global.util.oauth.component;
 
 import static com.ops.ops.global.util.oauth.exception.OAuthExceptionType.*;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.ops.ops.global.util.oauth.exception.OAuthException;
 import com.ops.ops.global.util.oauth.dto.GoogleOAuthToken;
+import com.ops.ops.global.util.oauth.exception.OAuthException;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -25,123 +24,161 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class GoogleOauth implements SocialOauth {
 
-	@Value("${spring.oauth2.google.url}")
-	private String GOOGLE_SNS_URL;
+    @Value("${spring.oauth2.google.url}")
+    private String GOOGLE_SNS_URL;
 
-	@Value("${spring.oauth2.google.client-id}")
-	private String GOOGLE_SNS_CLIENT_ID;
+    @Value("${spring.oauth2.google.client-id}")
+    private String GOOGLE_SNS_CLIENT_ID;
 
-	@Value("${spring.oauth2.google.callback-login-url}")
-	private String GOOGLE_SNS_CALLBACK_LOGIN_URL;
+    @Value("${spring.oauth2.google.callback-login-url}")
+    private String GOOGLE_SNS_CALLBACK_LOGIN_URL;
 
-	@Value("${spring.oauth2.google.client-secret}")
-	private String GOOGLE_SNS_CLIENT_SECRET;
+    @Value("${spring.oauth2.google.frontend-local-callback-login-url}")
+    private String GOOGLE_SNS_FRONTEND_LOCAL_CALLBACK_LOGIN_URL;
 
-	@Value("${spring.oauth2.google.scope}")
-	private String GOOGLE_DATA_ACCESS_SCOPE;
+    @Value("${spring.oauth2.google.client-secret}")
+    private String GOOGLE_SNS_CLIENT_SECRET;
 
-	private final ObjectMapper objectMapper;
-	private final RestTemplate restTemplate;
+    @Value("${spring.oauth2.google.scope}")
+    private String GOOGLE_DATA_ACCESS_SCOPE;
 
-	@Override
-	public String getOauthRedirectURL() {
-		Map<String, Object> params = new HashMap<>();
-		params.put("scope", GOOGLE_DATA_ACCESS_SCOPE);
-		params.put("response_type", "code");
-		params.put("client_id", GOOGLE_SNS_CLIENT_ID);
-		params.put("redirect_uri", GOOGLE_SNS_CALLBACK_LOGIN_URL);
+    private final ObjectMapper objectMapper;
+    private final RestTemplate restTemplate;
 
-		String parameterString = params.entrySet().stream()
-			.map(x -> x.getKey() + "=" + x.getValue())
-			.collect(Collectors.joining("&"));
+    @Override
+    public String getOauthRedirectURL() {
+        String callbackUrl = determineCallbackUrl();
 
-		return GOOGLE_SNS_URL + "?" + parameterString;
-	}
+        return UriComponentsBuilder.fromUriString(GOOGLE_SNS_URL)
+                .queryParam("scope", GOOGLE_DATA_ACCESS_SCOPE)
+                .queryParam("response_type", "code")
+                .queryParam("client_id", GOOGLE_SNS_CLIENT_ID)
+                .queryParam("redirect_uri", callbackUrl)
+                .encode()
+                .build()
+                .toUriString();
+    }
 
-	@Override
-	public <T> T getUserInfoByCode(String code, Class<T> userType) throws JsonProcessingException {
-		ResponseEntity<String> requestAccessToken = requestAccessToken(code);
-		GoogleOAuthToken oAuthToken = getAccessToken(requestAccessToken);
-		ResponseEntity<String> userInfo = requestUserInfo(oAuthToken);
-		return getUserInfo(userInfo, userType);
-	}
+    @Override
+    public <T> T getUserInfoByCode(String code, Class<T> userType) throws JsonProcessingException {
+        ResponseEntity<String> requestAccessToken = requestAccessToken(code);
+        GoogleOAuthToken oAuthToken = getAccessToken(requestAccessToken);
+        ResponseEntity<String> userInfo = requestUserInfo(oAuthToken);
+        return getUserInfo(userInfo, userType);
+    }
 
-	private ResponseEntity<String> requestAccessToken(String code) {
-		String GOOGLE_TOKEN_REQUEST_URL = "https://oauth2.googleapis.com/token";
+    private String determineCallbackUrl() {
+        try {
+            ServletRequestAttributes attributes =
+                    (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+            if (attributes == null) {
+                log.info(
+                        "RequestAttributes가 null - 기본 콜백 URL 사용: {}",
+                        GOOGLE_SNS_CALLBACK_LOGIN_URL);
+                return GOOGLE_SNS_CALLBACK_LOGIN_URL;
+            }
 
-		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-		params.add("code", code);
-		params.add("client_id", GOOGLE_SNS_CLIENT_ID);
-		params.add("client_secret", GOOGLE_SNS_CLIENT_SECRET);
-		params.add("redirect_uri", GOOGLE_SNS_CALLBACK_LOGIN_URL);
-		params.add("grant_type", "authorization_code");
+            HttpServletRequest request = attributes.getRequest();
 
-		HttpHeaders headers = new HttpHeaders();
-		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+            String origin = request.getHeader("Origin");
+            log.info("감지된 Origin 헤더: {}", origin);
 
-		HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(params, headers);
+            if (origin != null && origin.contains("localhost:5173")) {
+                return GOOGLE_SNS_FRONTEND_LOCAL_CALLBACK_LOGIN_URL;
+            }
 
-		try {
-			ResponseEntity<String> responseEntity = restTemplate.postForEntity(GOOGLE_TOKEN_REQUEST_URL, requestEntity, String.class);
+            return GOOGLE_SNS_CALLBACK_LOGIN_URL;
 
-			if (responseEntity.getStatusCode() == HttpStatus.OK) {
-				return responseEntity;
-			} else {
-				log.error("Google Access Token Request Failed: {}", responseEntity.getBody());
-				throw new OAuthException(SOCIAL_LOGIN_FAILED_AUTH_CODE);
-			}
-		} catch (RestClientException e) {
-			log.error("Google Access Token Request Server Error: {}", e.getMessage());
-			throw new OAuthException(SOCIAL_LOGIN_SERVER_ERROR);
-		}
-	}
+        } catch (Exception e) {
+            log.error("콜백 URL 결정 중 오류 발생", e);
+            return GOOGLE_SNS_CALLBACK_LOGIN_URL;
+        }
+    }
 
-	private GoogleOAuthToken getAccessToken(ResponseEntity<String> response) {
-		try {
-			// 구글 OAuth 토큰 응답 파싱
-			GoogleOAuthToken oAuthToken = objectMapper.readValue(response.getBody(), GoogleOAuthToken.class);
-			if (oAuthToken == null || oAuthToken.accessToken() == null) {
-				throw new OAuthException(FAILED_TO_GET_ACCESS_TOKEN);
-			}
-			return oAuthToken;
-		} catch (JsonProcessingException e) {
-			log.error("Failed to parse Google OAuth Token: {}", e.getMessage());
-			throw new OAuthException(FAILED_TO_GET_ACCESS_TOKEN);
-		}
-	}
+    private ResponseEntity<String> requestAccessToken(String code) {
+        String GOOGLE_TOKEN_REQUEST_URL = "https://oauth2.googleapis.com/token";
 
-	private ResponseEntity<String> requestUserInfo(GoogleOAuthToken oAuthToken) {
-		String GOOGLE_USERINFO_REQUEST_URL = "https://www.googleapis.com/oauth2/v1/userinfo";
+        String callbackUrl = determineCallbackUrl();
 
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Authorization", "Bearer " + oAuthToken.accessToken());
-		headers.add("Accept", MediaType.APPLICATION_JSON_VALUE);
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("code", code);
+        params.add("client_id", GOOGLE_SNS_CLIENT_ID);
+        params.add("client_secret", GOOGLE_SNS_CLIENT_SECRET);
+        params.add("redirect_uri", callbackUrl);
+        params.add("grant_type", "authorization_code");
 
-		HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
-		try {
-			return restTemplate.exchange(GOOGLE_USERINFO_REQUEST_URL, HttpMethod.GET, request, String.class);
-		} catch (RestClientException e) {
-			log.error("Google User Info Request Server Error: {}", e.getMessage());
-			throw new OAuthException(FAILED_TO_GET_SOCIAL_USER_INFO);
-		}
-	}
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
-	private <T> T getUserInfo(ResponseEntity<String> userInfoRes, Class<T> userType) {
-		try {
-			T googleUser = objectMapper.readValue(userInfoRes.getBody(), userType);
-			if (googleUser == null) {
-				throw new OAuthException(FAILED_TO_GET_SOCIAL_USER_INFO);
-			}
-			return googleUser;
-		} catch (JsonProcessingException e) {
-			log.error("Failed to parse Google User Info: {}", e.getMessage());
-			throw new OAuthException(FAILED_TO_GET_SOCIAL_USER_INFO);
-		}
-	}
+        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(params, headers);
+
+        try {
+            ResponseEntity<String> responseEntity =
+                    restTemplate.postForEntity(
+                            GOOGLE_TOKEN_REQUEST_URL, requestEntity, String.class);
+
+            if (responseEntity.getStatusCode() == HttpStatus.OK) {
+                return responseEntity;
+            } else {
+                log.error("Google Access Token Request Failed: {}", responseEntity.getBody());
+                throw new OAuthException(SOCIAL_LOGIN_FAILED_AUTH_CODE);
+            }
+        } catch (RestClientException e) {
+            log.error("Google Access Token Request Server Error: {}", e.getMessage());
+            throw new OAuthException(SOCIAL_LOGIN_SERVER_ERROR);
+        }
+    }
+
+    private GoogleOAuthToken getAccessToken(ResponseEntity<String> response) {
+        try {
+            GoogleOAuthToken oAuthToken =
+                    objectMapper.readValue(response.getBody(), GoogleOAuthToken.class);
+            if (oAuthToken == null || oAuthToken.accessToken() == null) {
+                throw new OAuthException(FAILED_TO_GET_ACCESS_TOKEN);
+            }
+            return oAuthToken;
+        } catch (JsonProcessingException e) {
+            log.error("Failed to parse Google OAuth Token: {}", e.getMessage());
+            throw new OAuthException(FAILED_TO_GET_ACCESS_TOKEN);
+        }
+    }
+
+    private ResponseEntity<String> requestUserInfo(GoogleOAuthToken oAuthToken) {
+        String GOOGLE_USERINFO_REQUEST_URL = "https://www.googleapis.com/oauth2/v1/userinfo";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + oAuthToken.accessToken());
+        headers.add("Accept", MediaType.APPLICATION_JSON_VALUE);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+        try {
+            return restTemplate.exchange(
+                    GOOGLE_USERINFO_REQUEST_URL, HttpMethod.GET, request, String.class);
+        } catch (RestClientException e) {
+            log.error("Google User Info Request Server Error: {}", e.getMessage());
+            throw new OAuthException(FAILED_TO_GET_SOCIAL_USER_INFO);
+        }
+    }
+
+    private <T> T getUserInfo(ResponseEntity<String> userInfoRes, Class<T> userType) {
+        try {
+            T googleUser = objectMapper.readValue(userInfoRes.getBody(), userType);
+            if (googleUser == null) {
+                throw new OAuthException(FAILED_TO_GET_SOCIAL_USER_INFO);
+            }
+            return googleUser;
+        } catch (JsonProcessingException e) {
+            log.error("Failed to parse Google User Info: {}", e.getMessage());
+            throw new OAuthException(FAILED_TO_GET_SOCIAL_USER_INFO);
+        }
+    }
 }

--- a/src/main/java/com/ops/ops/global/util/oauth/component/GoogleOauth.java
+++ b/src/main/java/com/ops/ops/global/util/oauth/component/GoogleOauth.java
@@ -2,17 +2,16 @@ package com.ops.ops.global.util.oauth.component;
 
 import static com.ops.ops.global.util.oauth.exception.OAuthExceptionType.*;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.ops.ops.global.util.oauth.exception.OAuthException;
 import com.ops.ops.global.util.oauth.dto.GoogleOAuthToken;
+import com.ops.ops.global.util.oauth.exception.OAuthException;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -25,123 +24,168 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class GoogleOauth implements SocialOauth {
 
-	@Value("${spring.oauth2.google.url}")
-	private String GOOGLE_SNS_URL;
+    @Value("${spring.oauth2.google.url}")
+    private String GOOGLE_SNS_URL;
 
-	@Value("${spring.oauth2.google.client-id}")
-	private String GOOGLE_SNS_CLIENT_ID;
+    @Value("${spring.oauth2.google.client-id}")
+    private String GOOGLE_SNS_CLIENT_ID;
 
-	@Value("${spring.oauth2.google.callback-login-url}")
-	private String GOOGLE_SNS_CALLBACK_LOGIN_URL;
+    @Value("${spring.oauth2.google.callback-login-url}")
+    private String GOOGLE_SNS_CALLBACK_LOGIN_URL;
 
-	@Value("${spring.oauth2.google.client-secret}")
-	private String GOOGLE_SNS_CLIENT_SECRET;
+    @Value("${spring.oauth2.google.frontend-local-callback-login-url}")
+    private String GOOGLE_SNS_FRONTEND_LOCAL_CALLBACK_LOGIN_URL;
 
-	@Value("${spring.oauth2.google.scope}")
-	private String GOOGLE_DATA_ACCESS_SCOPE;
+    @Value("${spring.oauth2.google.client-secret}")
+    private String GOOGLE_SNS_CLIENT_SECRET;
 
-	private final ObjectMapper objectMapper;
-	private final RestTemplate restTemplate;
+    @Value("${spring.oauth2.google.scope}")
+    private String GOOGLE_DATA_ACCESS_SCOPE;
 
-	@Override
-	public String getOauthRedirectURL() {
-		Map<String, Object> params = new HashMap<>();
-		params.put("scope", GOOGLE_DATA_ACCESS_SCOPE);
-		params.put("response_type", "code");
-		params.put("client_id", GOOGLE_SNS_CLIENT_ID);
-		params.put("redirect_uri", GOOGLE_SNS_CALLBACK_LOGIN_URL);
+    private final ObjectMapper objectMapper;
+    private final RestTemplate restTemplate;
 
-		String parameterString = params.entrySet().stream()
-			.map(x -> x.getKey() + "=" + x.getValue())
-			.collect(Collectors.joining("&"));
+    @Override
+    public String getOauthRedirectURL() {
+        String callbackUrl = determineCallbackUrl();
 
-		return GOOGLE_SNS_URL + "?" + parameterString;
-	}
+        Map<String, Object> params = new HashMap<>();
+        params.put("scope", GOOGLE_DATA_ACCESS_SCOPE);
+        params.put("response_type", "code");
+        params.put("client_id", GOOGLE_SNS_CLIENT_ID);
+        params.put("redirect_uri", callbackUrl);
 
-	@Override
-	public <T> T getUserInfoByCode(String code, Class<T> userType) throws JsonProcessingException {
-		ResponseEntity<String> requestAccessToken = requestAccessToken(code);
-		GoogleOAuthToken oAuthToken = getAccessToken(requestAccessToken);
-		ResponseEntity<String> userInfo = requestUserInfo(oAuthToken);
-		return getUserInfo(userInfo, userType);
-	}
+        String parameterString =
+                params.entrySet().stream()
+                        .map(x -> x.getKey() + "=" + x.getValue())
+                        .collect(Collectors.joining("&"));
 
-	private ResponseEntity<String> requestAccessToken(String code) {
-		String GOOGLE_TOKEN_REQUEST_URL = "https://oauth2.googleapis.com/token";
+        return GOOGLE_SNS_URL + "?" + parameterString;
+    }
 
-		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-		params.add("code", code);
-		params.add("client_id", GOOGLE_SNS_CLIENT_ID);
-		params.add("client_secret", GOOGLE_SNS_CLIENT_SECRET);
-		params.add("redirect_uri", GOOGLE_SNS_CALLBACK_LOGIN_URL);
-		params.add("grant_type", "authorization_code");
+    @Override
+    public <T> T getUserInfoByCode(String code, Class<T> userType) throws JsonProcessingException {
+        ResponseEntity<String> requestAccessToken = requestAccessToken(code);
+        GoogleOAuthToken oAuthToken = getAccessToken(requestAccessToken);
+        ResponseEntity<String> userInfo = requestUserInfo(oAuthToken);
+        return getUserInfo(userInfo, userType);
+    }
 
-		HttpHeaders headers = new HttpHeaders();
-		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+    private String determineCallbackUrl() {
+        try {
+            ServletRequestAttributes attributes =
+                    (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+            if (attributes == null) {
+                log.info(
+                        "RequestAttributes가 null - 기본 콜백 URL 사용: {}",
+                        GOOGLE_SNS_CALLBACK_LOGIN_URL);
+                return GOOGLE_SNS_CALLBACK_LOGIN_URL;
+            }
 
-		HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(params, headers);
+            HttpServletRequest request = attributes.getRequest();
 
-		try {
-			ResponseEntity<String> responseEntity = restTemplate.postForEntity(GOOGLE_TOKEN_REQUEST_URL, requestEntity, String.class);
+            String origin = request.getHeader("Origin");
+            log.info("감지된 Origin 헤더: {}", origin);
 
-			if (responseEntity.getStatusCode() == HttpStatus.OK) {
-				return responseEntity;
-			} else {
-				log.error("Google Access Token Request Failed: {}", responseEntity.getBody());
-				throw new OAuthException(SOCIAL_LOGIN_FAILED_AUTH_CODE);
-			}
-		} catch (RestClientException e) {
-			log.error("Google Access Token Request Server Error: {}", e.getMessage());
-			throw new OAuthException(SOCIAL_LOGIN_SERVER_ERROR);
-		}
-	}
+            if (origin != null && origin.contains("localhost:5173")) {
+                return GOOGLE_SNS_FRONTEND_LOCAL_CALLBACK_LOGIN_URL;
+            }
 
-	private GoogleOAuthToken getAccessToken(ResponseEntity<String> response) {
-		try {
-			// 구글 OAuth 토큰 응답 파싱
-			GoogleOAuthToken oAuthToken = objectMapper.readValue(response.getBody(), GoogleOAuthToken.class);
-			if (oAuthToken == null || oAuthToken.accessToken() == null) {
-				throw new OAuthException(FAILED_TO_GET_ACCESS_TOKEN);
-			}
-			return oAuthToken;
-		} catch (JsonProcessingException e) {
-			log.error("Failed to parse Google OAuth Token: {}", e.getMessage());
-			throw new OAuthException(FAILED_TO_GET_ACCESS_TOKEN);
-		}
-	}
+            return GOOGLE_SNS_CALLBACK_LOGIN_URL;
 
-	private ResponseEntity<String> requestUserInfo(GoogleOAuthToken oAuthToken) {
-		String GOOGLE_USERINFO_REQUEST_URL = "https://www.googleapis.com/oauth2/v1/userinfo";
+        } catch (Exception e) {
+            log.error("콜백 URL 결정 중 오류 발생: {}", e.getMessage());
+            return GOOGLE_SNS_CALLBACK_LOGIN_URL;
+        }
+    }
 
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Authorization", "Bearer " + oAuthToken.accessToken());
-		headers.add("Accept", MediaType.APPLICATION_JSON_VALUE);
+    private ResponseEntity<String> requestAccessToken(String code) {
+        String GOOGLE_TOKEN_REQUEST_URL = "https://oauth2.googleapis.com/token";
 
-		HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
-		try {
-			return restTemplate.exchange(GOOGLE_USERINFO_REQUEST_URL, HttpMethod.GET, request, String.class);
-		} catch (RestClientException e) {
-			log.error("Google User Info Request Server Error: {}", e.getMessage());
-			throw new OAuthException(FAILED_TO_GET_SOCIAL_USER_INFO);
-		}
-	}
+        String callbackUrl = determineCallbackUrl();
 
-	private <T> T getUserInfo(ResponseEntity<String> userInfoRes, Class<T> userType) {
-		try {
-			T googleUser = objectMapper.readValue(userInfoRes.getBody(), userType);
-			if (googleUser == null) {
-				throw new OAuthException(FAILED_TO_GET_SOCIAL_USER_INFO);
-			}
-			return googleUser;
-		} catch (JsonProcessingException e) {
-			log.error("Failed to parse Google User Info: {}", e.getMessage());
-			throw new OAuthException(FAILED_TO_GET_SOCIAL_USER_INFO);
-		}
-	}
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("code", code);
+        params.add("client_id", GOOGLE_SNS_CLIENT_ID);
+        params.add("client_secret", GOOGLE_SNS_CLIENT_SECRET);
+        params.add("redirect_uri", callbackUrl);
+        params.add("grant_type", "authorization_code");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(params, headers);
+
+        try {
+            ResponseEntity<String> responseEntity =
+                    restTemplate.postForEntity(
+                            GOOGLE_TOKEN_REQUEST_URL, requestEntity, String.class);
+
+            if (responseEntity.getStatusCode() == HttpStatus.OK) {
+                return responseEntity;
+            } else {
+                log.error("Google Access Token Request Failed: {}", responseEntity.getBody());
+                throw new OAuthException(SOCIAL_LOGIN_FAILED_AUTH_CODE);
+            }
+        } catch (RestClientException e) {
+            log.error("Google Access Token Request Server Error: {}", e.getMessage());
+            throw new OAuthException(SOCIAL_LOGIN_SERVER_ERROR);
+        }
+    }
+
+    private GoogleOAuthToken getAccessToken(ResponseEntity<String> response) {
+        try {
+            GoogleOAuthToken oAuthToken =
+                    objectMapper.readValue(response.getBody(), GoogleOAuthToken.class);
+            if (oAuthToken == null || oAuthToken.accessToken() == null) {
+                throw new OAuthException(FAILED_TO_GET_ACCESS_TOKEN);
+            }
+            return oAuthToken;
+        } catch (JsonProcessingException e) {
+            log.error("Failed to parse Google OAuth Token: {}", e.getMessage());
+            throw new OAuthException(FAILED_TO_GET_ACCESS_TOKEN);
+        }
+    }
+
+    private ResponseEntity<String> requestUserInfo(GoogleOAuthToken oAuthToken) {
+        String GOOGLE_USERINFO_REQUEST_URL = "https://www.googleapis.com/oauth2/v1/userinfo";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + oAuthToken.accessToken());
+        headers.add("Accept", MediaType.APPLICATION_JSON_VALUE);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+        try {
+            return restTemplate.exchange(
+                    GOOGLE_USERINFO_REQUEST_URL, HttpMethod.GET, request, String.class);
+        } catch (RestClientException e) {
+            log.error("Google User Info Request Server Error: {}", e.getMessage());
+            throw new OAuthException(FAILED_TO_GET_SOCIAL_USER_INFO);
+        }
+    }
+
+    private <T> T getUserInfo(ResponseEntity<String> userInfoRes, Class<T> userType) {
+        try {
+            T googleUser = objectMapper.readValue(userInfoRes.getBody(), userType);
+            if (googleUser == null) {
+                throw new OAuthException(FAILED_TO_GET_SOCIAL_USER_INFO);
+            }
+            return googleUser;
+        } catch (JsonProcessingException e) {
+            log.error("Failed to parse Google User Info: {}", e.getMessage());
+            throw new OAuthException(FAILED_TO_GET_SOCIAL_USER_INFO);
+        }
+    }
 }


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #85 

## 📜 작업 내용

- 현재 배포된 서버의 구글 콜백 URL은 https://swpms.pnu.app/api/oauth/google/callback로 고정되어 있습니다!
- 다만, 프론트엔드 로컬 개발 환경에서는 localhost:5173을 사용하고 있어, 프론트분들이 로컬에서 작업 시에 구글 OAuth 콜백 처리 시 라우터가 동적으로 URL을 판단하지 못하는 문제가 발생
- 따라서 개발과 배포 환경에서 서로 다른 콜백 URL을 동적으로 처리할 수 있도록 백엔드 로직을 개선 필요하여 작업하였습니다!
    - 개발 환경: 구글 OAuth 콜백이 http://localhost:5173/api/oauth/google/callback로 처리
    - 배포 환경: 기존과 동일하게 https://swpms.pnu.app/api/oauth/google/callback로 처리


## 💬 리뷰 요구사항
- 포매터 변경으로 코드 리뷰하기 정말 힘드실 거 같은데 핵심은 `determineCallbackUrl` 메서드를 만들어서 콜백 url을 환경에 맞춰 변경하는 작업을 수행헀다는 점입니다!
- 우테코 코드 포매터를 아래와 같이 설정하였는데 너무 많이 바뀌어서 제가 올바르게 설정한지 모르겠더라구요 ㅠ.ㅠ 혹시 다른 분들도 저렇게 설정하셨을까요-?
- 참고한 블로그 : [블로그 바로가기](https://velog.io/@pgmjun/IntelliJ-%EC%BD%94%EB%93%9C-%EC%8A%A4%ED%83%80%EC%9D%BC%EC%9D%84-%EC%84%A4%EC%A0%95%ED%95%B4%EB%B3%B4%EC%9E%90-feat.%EC%9A%B0%ED%85%8C%EC%BD%94)

<img width="850" height="692" alt="스크린샷 2025-07-11 오후 2 10 41" src="https://github.com/user-attachments/assets/b01d5ca6-c226-46da-814e-939e2c59a774" />
<img width="850" height="685" alt="스크린샷 2025-07-11 오후 2 11 09" src="https://github.com/user-attachments/assets/3bc146be-02c9-445d-bbaa-f0866aa6a512" />

## ✨ 기타
- 화이팅~!