### PR TITLE
Bug/#88 이미지 변환 오류 해결

### DIFF
--- a/src/main/java/com/ops/ops/modules/file/exception/FileExceptionType.java
+++ b/src/main/java/com/ops/ops/modules/file/exception/FileExceptionType.java
@@ -11,7 +11,7 @@ public enum FileExceptionType implements BaseExceptionType {
     NOT_INCLUDE_ID(HttpStatus.BAD_REQUEST, "ID는 반드시 포함되어야 합니다"),
     EXCEED_PREVIEW_LIMIT(HttpStatus.BAD_REQUEST, "프리뷰 이미지는 6장 이하입니다"),
     NOT_EXISTS_PHYSICAL_FILE(HttpStatus.NOT_FOUND, "물리적 파일이 존재하지 않습니다"),
-    NOT_WEBP_CONVERTED(HttpStatus.CONFLICT, "이미지 변환중 입니다"),
+    NOT_WEBP_CONVERTED(HttpStatus.ACCEPTED, "이미지 변환중 입니다"),
     ;
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,8 +17,8 @@ spring:
 
   servlet:
     multipart:
-      max-file-size: 2MB
-      max-request-size: 12MB
+      max-file-size: 5MB
+      max-request-size: 30MB
 
 cors:
   allow:


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #88 

## 📜 작업 내용

> 1. 이미지 변환 오류 수정했습니다
>  - 이미지 스트림을 가져오는 시점에 스트림이 닫혀 있을 수도 있다는 점을 발견하여 수정했습니다.
> 2. 프론트 담당자의 요청으로 이미지 업로드 제한을 5MB로 상향하였습니다.
> 3. 이미지 변환중이라는 상태를 명확히 하기 위해 상태코드를 기존의 409에서 202로 수정하였습니다. 

## 💬 리뷰 요구사항

> 리뷰 환영합니다~!

## ✨ 기타
