### PR TITLE
Feature/#101 대회 조회 시간 응답 형태 수정

### DIFF
--- a/src/main/java/com/ops/ops/modules/contest/application/dto/response/ContestResponse.java
+++ b/src/main/java/com/ops/ops/modules/contest/application/dto/response/ContestResponse.java
@@ -1,12 +1,10 @@
 package com.ops.ops.modules.contest.application.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 
 public record ContestResponse(
         Long contestId,
         String contestName,
-        @JsonFormat(pattern = "yy.MM.dd HH:mm")
         LocalDateTime updatedAt
 ) {
 }


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #101 

## 📜 작업 내용

> 프론트 팀의 요청에 따라 전체 대회 조회의 응답 중 생성 시간을 일반 DateTime으로 변경하였습니다.

## 💬 리뷰 요구사항

> .

## ✨ 기타
