### PR TITLE
Bug/#100-팀-삭제-오류

### DIFF
--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
@@ -27,6 +27,8 @@ import com.ops.ops.modules.team.application.dto.request.TeamDetailUpdateRequest;
 import com.ops.ops.modules.team.application.dto.response.TeamCreateResponse;
 import com.ops.ops.modules.team.domain.Team;
 import com.ops.ops.modules.team.domain.dao.TeamRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -82,6 +84,9 @@ public class TeamCommandService {
         }
     }
 
+    @PersistenceContext
+    private EntityManager em;
+
     public void deleteTeam(final Long teamId) {
         final Team team = teamConvenience.getValidateExistTeam(teamId);
         final List<Long> memberIds = teamMemberConvenience.getTeamMemberIdsByTeamId(teamId);
@@ -92,7 +97,13 @@ public class TeamCommandService {
         teamCommentConvenience.deleteAllByTeamId(teamId);
         teamLikeConvenience.deleteAllByTeamId(teamId);
         teamMemberConvenience.deleteAllByTeamId(teamId);
+
+        em.flush();
+        em.clear();
+
         teamRepository.delete(team);
+
+//        team.setIsDeleted(true);
     }
 
     public void updateTeamDetail(final Long teamId, final Member member, final TeamDetailUpdateRequest request) {

--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
@@ -18,7 +18,9 @@ import com.ops.ops.modules.file.domain.dao.FileRepository;
 import com.ops.ops.modules.file.exception.FileException;
 import com.ops.ops.modules.member.application.convenience.MemberConvenience;
 import com.ops.ops.modules.member.domain.Member;
+import com.ops.ops.modules.team.application.convenience.TeamCommentConvenience;
 import com.ops.ops.modules.team.application.convenience.TeamConvenience;
+import com.ops.ops.modules.team.application.convenience.TeamLikeConvenience;
 import com.ops.ops.modules.team.application.convenience.TeamMemberConvenience;
 import com.ops.ops.modules.team.application.dto.request.TeamCreateRequest;
 import com.ops.ops.modules.team.application.dto.request.TeamDetailUpdateRequest;
@@ -48,6 +50,8 @@ public class TeamCommandService {
     private final TeamConvenience teamConvenience;
     private final TeamMemberConvenience teamMemberConvenience;
     private final MemberConvenience memberConvenience;
+    private final TeamCommentConvenience teamCommentConvenience;
+    private final TeamLikeConvenience teamLikeConvenience;
 
     public void saveThumbnailImage(final Long teamId, final MultipartFile image, final FileImageType thumbnailType) {
         teamConvenience.validateExistTeam(teamId);
@@ -84,6 +88,10 @@ public class TeamCommandService {
         final Long leaderId = memberConvenience.getLeaderIdByMemberIds(memberIds);
         final Member leader = memberConvenience.getValidateExistMember(leaderId);
         leader.updateRole();
+
+        teamCommentConvenience.deleteAllByTeamId(teamId);
+        teamLikeConvenience.deleteAllByTeamId(teamId);
+        teamMemberConvenience.deleteAllByTeamId(teamId);
         teamRepository.delete(team);
     }
 

--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
@@ -27,8 +27,6 @@ import com.ops.ops.modules.team.application.dto.request.TeamDetailUpdateRequest;
 import com.ops.ops.modules.team.application.dto.response.TeamCreateResponse;
 import com.ops.ops.modules.team.domain.Team;
 import com.ops.ops.modules.team.domain.dao.TeamRepository;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -84,9 +82,6 @@ public class TeamCommandService {
         }
     }
 
-    @PersistenceContext
-    private EntityManager em;
-
     public void deleteTeam(final Long teamId) {
         final Team team = teamConvenience.getValidateExistTeam(teamId);
         final List<Long> memberIds = teamMemberConvenience.getTeamMemberIdsByTeamId(teamId);
@@ -98,12 +93,7 @@ public class TeamCommandService {
         teamLikeConvenience.deleteAllByTeamId(teamId);
         teamMemberConvenience.deleteAllByTeamId(teamId);
 
-        em.flush();
-        em.clear();
-
         teamRepository.delete(team);
-
-//        team.setIsDeleted(true);
     }
 
     public void updateTeamDetail(final Long teamId, final Member member, final TeamDetailUpdateRequest request) {

--- a/src/main/java/com/ops/ops/modules/team/application/convenience/TeamCommentConvenience.java
+++ b/src/main/java/com/ops/ops/modules/team/application/convenience/TeamCommentConvenience.java
@@ -5,6 +5,7 @@ import static com.ops.ops.modules.team.exception.TeamCommentExceptionType.NOT_FO
 import com.ops.ops.modules.team.domain.TeamComment;
 import com.ops.ops.modules.team.domain.dao.TeamCommentRepository;
 import com.ops.ops.modules.team.exception.TeamCommentException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,5 +19,12 @@ public class TeamCommentConvenience {
 
     public TeamComment getValidateExistComment(final Long commentId) {
         return teamCommentRepository.findById(commentId).orElseThrow(() -> new TeamCommentException(NOT_FOUND_COMMENT));
+    }
+
+    public void deleteAllByTeamId(final Long teamId) {
+        final List<TeamComment> teamComments = teamCommentRepository.findAllByTeamId(teamId);
+        for (TeamComment teamComment : teamComments) {
+            teamCommentRepository.delete(teamComment);
+        }
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/application/convenience/TeamCommentConvenience.java
+++ b/src/main/java/com/ops/ops/modules/team/application/convenience/TeamCommentConvenience.java
@@ -5,7 +5,6 @@ import static com.ops.ops.modules.team.exception.TeamCommentExceptionType.NOT_FO
 import com.ops.ops.modules.team.domain.TeamComment;
 import com.ops.ops.modules.team.domain.dao.TeamCommentRepository;
 import com.ops.ops.modules.team.exception.TeamCommentException;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,10 +20,8 @@ public class TeamCommentConvenience {
         return teamCommentRepository.findById(commentId).orElseThrow(() -> new TeamCommentException(NOT_FOUND_COMMENT));
     }
 
+    @Transactional
     public void deleteAllByTeamId(final Long teamId) {
-        final List<TeamComment> teamComments = teamCommentRepository.findAllByTeamId(teamId);
-        for (TeamComment teamComment : teamComments) {
-            teamCommentRepository.delete(teamComment);
-        }
+        teamCommentRepository.deleteAllByTeamId(teamId);
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/application/convenience/TeamCommentConvenience.java
+++ b/src/main/java/com/ops/ops/modules/team/application/convenience/TeamCommentConvenience.java
@@ -20,7 +20,6 @@ public class TeamCommentConvenience {
         return teamCommentRepository.findById(commentId).orElseThrow(() -> new TeamCommentException(NOT_FOUND_COMMENT));
     }
 
-    @Transactional
     public void deleteAllByTeamId(final Long teamId) {
         teamCommentRepository.deleteAllByTeamId(teamId);
     }

--- a/src/main/java/com/ops/ops/modules/team/application/convenience/TeamLikeConvenience.java
+++ b/src/main/java/com/ops/ops/modules/team/application/convenience/TeamLikeConvenience.java
@@ -32,4 +32,11 @@ public class TeamLikeConvenience {
         return teams.stream().map(team -> TeamSummaryResponse.from(team, likeMap.getOrDefault(team.getId(), false)))
                 .toList();
     }
+
+    public void deleteAllByTeamId(final Long teamId) {
+        final List<TeamLike> teamLikes = teamLikeRepository.findAllByTeamId(teamId);
+        for (TeamLike teamLike : teamLikes) {
+            teamLikeRepository.delete(teamLike);
+        }
+    }
 }

--- a/src/main/java/com/ops/ops/modules/team/application/convenience/TeamLikeConvenience.java
+++ b/src/main/java/com/ops/ops/modules/team/application/convenience/TeamLikeConvenience.java
@@ -33,7 +33,6 @@ public class TeamLikeConvenience {
                 .toList();
     }
 
-    @Transactional
     public void deleteAllByTeamId(final Long teamId) {
         teamLikeRepository.deleteAllByTeamId(teamId);
     }

--- a/src/main/java/com/ops/ops/modules/team/application/convenience/TeamLikeConvenience.java
+++ b/src/main/java/com/ops/ops/modules/team/application/convenience/TeamLikeConvenience.java
@@ -33,10 +33,8 @@ public class TeamLikeConvenience {
                 .toList();
     }
 
+    @Transactional
     public void deleteAllByTeamId(final Long teamId) {
-        final List<TeamLike> teamLikes = teamLikeRepository.findAllByTeamId(teamId);
-        for (TeamLike teamLike : teamLikes) {
-            teamLikeRepository.delete(teamLike);
-        }
+        teamLikeRepository.deleteAllByTeamId(teamId);
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/application/convenience/TeamMemberConvenience.java
+++ b/src/main/java/com/ops/ops/modules/team/application/convenience/TeamMemberConvenience.java
@@ -31,7 +31,6 @@ public class TeamMemberConvenience {
                 .toList();
     }
 
-    @Transactional
     public void deleteAllByTeamId(final Long teamId) {
         teamMemberRepository.deleteAllByTeamId(teamId);
     }

--- a/src/main/java/com/ops/ops/modules/team/application/convenience/TeamMemberConvenience.java
+++ b/src/main/java/com/ops/ops/modules/team/application/convenience/TeamMemberConvenience.java
@@ -31,10 +31,8 @@ public class TeamMemberConvenience {
                 .toList();
     }
 
+    @Transactional
     public void deleteAllByTeamId(final Long teamId) {
-        final List<TeamMember> teamMembers = teamMemberRepository.findAllByTeamId(teamId);
-        for (TeamMember teamMember : teamMembers) {
-            teamMemberRepository.delete(teamMember);
-        }
+        teamMemberRepository.deleteAllByTeamId(teamId);
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/application/convenience/TeamMemberConvenience.java
+++ b/src/main/java/com/ops/ops/modules/team/application/convenience/TeamMemberConvenience.java
@@ -30,4 +30,11 @@ public class TeamMemberConvenience {
                 .map(TeamMember::getMemberId)
                 .toList();
     }
+
+    public void deleteAllByTeamId(final Long teamId) {
+        final List<TeamMember> teamMembers = teamMemberRepository.findAllByTeamId(teamId);
+        for (TeamMember teamMember : teamMembers) {
+            teamMemberRepository.delete(teamMember);
+        }
+    }
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/Team.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/Team.java
@@ -104,8 +104,4 @@ public class Team extends BaseEntity {
     public boolean isLeaderNameChanged(String newLeaderName) {
         return !this.getLeaderName().equals(newLeaderName);
     }
-
-    public void setIsDeleted(final boolean isDeleted) {
-        this.isDeleted = isDeleted;
-    }
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/Team.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/Team.java
@@ -24,7 +24,7 @@ import org.hibernate.annotations.SQLRestriction;
 public class Team extends BaseEntity {
 
     private static final int MAX_OVERVIEW_LENGTH = 3000;
-    
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -103,5 +103,9 @@ public class Team extends BaseEntity {
 
     public boolean isLeaderNameChanged(String newLeaderName) {
         return !this.getLeaderName().equals(newLeaderName);
+    }
+
+    public void setIsDeleted(final boolean isDeleted) {
+        this.isDeleted = isDeleted;
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/dao/TeamCommentRepository.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/dao/TeamCommentRepository.java
@@ -1,10 +1,11 @@
 package com.ops.ops.modules.team.domain.dao;
 
-import java.util.List;
-
 import com.ops.ops.modules.team.domain.TeamComment;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeamCommentRepository extends JpaRepository<TeamComment, Long> {
-	List<TeamComment> findAllByTeamIdOrderByIdDesc(Long id);
+    List<TeamComment> findAllByTeamIdOrderByIdDesc(Long id);
+
+    List<TeamComment> findAllByTeamId(Long teamId);
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/dao/TeamCommentRepository.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/dao/TeamCommentRepository.java
@@ -3,13 +3,9 @@ package com.ops.ops.modules.team.domain.dao;
 import com.ops.ops.modules.team.domain.TeamComment;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 
 public interface TeamCommentRepository extends JpaRepository<TeamComment, Long> {
     List<TeamComment> findAllByTeamIdOrderByIdDesc(Long id);
 
-    @Modifying
-    @Query("DELETE FROM TeamComment tc WHERE tc.team.id = :teamId")
     void deleteAllByTeamId(Long teamId);
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/dao/TeamCommentRepository.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/dao/TeamCommentRepository.java
@@ -3,9 +3,13 @@ package com.ops.ops.modules.team.domain.dao;
 import com.ops.ops.modules.team.domain.TeamComment;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TeamCommentRepository extends JpaRepository<TeamComment, Long> {
     List<TeamComment> findAllByTeamIdOrderByIdDesc(Long id);
 
-    List<TeamComment> findAllByTeamId(Long teamId);
+    @Modifying
+    @Query("DELETE FROM TeamComment tc WHERE tc.team.id = :teamId")
+    void deleteAllByTeamId(Long teamId);
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/dao/TeamLikeRepository.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/dao/TeamLikeRepository.java
@@ -6,6 +6,7 @@ import com.ops.ops.modules.team.domain.TeamLike;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface TeamLikeRepository extends JpaRepository<TeamLike, Long> {
@@ -22,5 +23,8 @@ public interface TeamLikeRepository extends JpaRepository<TeamLike, Long> {
 
     List<TeamLike> findAllByMemberIdAndTeamIn(Long id, List<Team> teams);
 
-    List<TeamLike> findAllByTeamId(Long teamId);
+    @Modifying
+    @Query("DELETE FROM TeamLike tl WHERE tl.team.id = :teamId")
+    void deleteAllByTeamId(Long teamId);
+
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/dao/TeamLikeRepository.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/dao/TeamLikeRepository.java
@@ -1,26 +1,26 @@
 package com.ops.ops.modules.team.domain.dao;
 
-import java.util.List;
-import java.util.Optional;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-
 import com.ops.ops.modules.team.application.dto.TeamLikeCountDto;
 import com.ops.ops.modules.team.domain.Team;
 import com.ops.ops.modules.team.domain.TeamLike;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TeamLikeRepository extends JpaRepository<TeamLike, Long> {
-	Optional<TeamLike> findByMemberIdAndTeam(Long memberId, Team team);
+    Optional<TeamLike> findByMemberIdAndTeam(Long memberId, Team team);
 
-	@Query("SELECT t.team.id AS teamId, COUNT(t) AS likeCount FROM TeamLike t WHERE t.isLiked = true AND t.team IN :teams GROUP BY t.team.id")
-	List<TeamLikeCountDto> findTeamLikeCountGroupedByTeams(List<Team> teams);
+    @Query("SELECT t.team.id AS teamId, COUNT(t) AS likeCount FROM TeamLike t WHERE t.isLiked = true AND t.team IN :teams GROUP BY t.team.id")
+    List<TeamLikeCountDto> findTeamLikeCountGroupedByTeams(List<Team> teams);
 
-	@Query("SELECT COUNT(DISTINCT t.memberId) FROM TeamLike t WHERE t.isLiked = true AND t.team IN :teams")
-	long countDistinctMemberIdsByIsLikedTrueAndTeams(List<Team> teams);
+    @Query("SELECT COUNT(DISTINCT t.memberId) FROM TeamLike t WHERE t.isLiked = true AND t.team IN :teams")
+    long countDistinctMemberIdsByIsLikedTrueAndTeams(List<Team> teams);
 
-	@Query("SELECT COUNT(t) FROM TeamLike t WHERE t.isLiked = true AND t.team IN :teams")
-	long countByIsLikedTrueAndTeams(List<Team> teams);
+    @Query("SELECT COUNT(t) FROM TeamLike t WHERE t.isLiked = true AND t.team IN :teams")
+    long countByIsLikedTrueAndTeams(List<Team> teams);
 
-	List<TeamLike> findAllByMemberIdAndTeamIn(Long id, List<Team> teams);
+    List<TeamLike> findAllByMemberIdAndTeamIn(Long id, List<Team> teams);
+
+    List<TeamLike> findAllByTeamId(Long teamId);
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/dao/TeamLikeRepository.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/dao/TeamLikeRepository.java
@@ -6,7 +6,6 @@ import com.ops.ops.modules.team.domain.TeamLike;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface TeamLikeRepository extends JpaRepository<TeamLike, Long> {
@@ -23,8 +22,5 @@ public interface TeamLikeRepository extends JpaRepository<TeamLike, Long> {
 
     List<TeamLike> findAllByMemberIdAndTeamIn(Long id, List<Team> teams);
 
-    @Modifying
-    @Query("DELETE FROM TeamLike tl WHERE tl.team.id = :teamId")
     void deleteAllByTeamId(Long teamId);
-
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/dao/TeamMemberRepository.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/dao/TeamMemberRepository.java
@@ -5,8 +5,6 @@ import com.ops.ops.modules.team.domain.TeamMember;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 
 public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     List<TeamMember> findAllByTeamId(Long id);
@@ -15,7 +13,5 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
 
     Optional<TeamMember> findByMemberIdAndTeam(Long memberId, Team team);
 
-    @Modifying
-    @Query("DELETE FROM TeamMember tm WHERE tm.team.id = :teamId")
     void deleteAllByTeamId(Long teamId);
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/dao/TeamMemberRepository.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/dao/TeamMemberRepository.java
@@ -5,6 +5,8 @@ import com.ops.ops.modules.team.domain.TeamMember;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     List<TeamMember> findAllByTeamId(Long id);
@@ -12,4 +14,8 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     Optional<TeamMember> findByMemberId(Long memberId);
 
     Optional<TeamMember> findByMemberIdAndTeam(Long memberId, Team team);
+
+    @Modifying
+    @Query("DELETE FROM TeamMember tm WHERE tm.team.id = :teamId")
+    void deleteAllByTeamId(Long teamId);
 }


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #100 

## 📜 작업 내용

> 팀 삭제 시 TransientObjectException 에러가 발생했습니다. 부모 엔티티(Team)을 삭제할 때, 자식 엔티티들인 TeamMember, TeamComment, TeamLike가 여전히 존재해서 발생한 예외인 것 같습니다. 그래서 Team 삭제 전에 연관된 자식 엔티티들을 전부 제거 후 삭제를 수행하도록 변경했습니다!

+ 07.18 : [fix : Team 과 연관된 엔티티를 쿼리로 삭제]
TeamMember, TeamComment, TeamLike를 각각 한 번의 delete 쿼리로 삭제되도록 변경했는데 TransientObjectException 에러가 발생했습니다
```
@PersistenceContext
private EntityManager em;
   
em.flush();
em.clear();
teamRepository.delete(team);
```
이 코드를 추가하여 변경 내용을 DB에 즉시 반영 후 캐시에 남아 있는 모든 엔티티 인스턴스를 제거하니 작동이 되었습니다... 
이렇게 해결해도 될까요??😭😭

또는 ```teamRepository.delete(team);```를 ```team.setIsDeleted(true);```로 변경했더니 정상 작동했습니다!

## 💬 리뷰 요구사항

> 수정해야 할 부분 있다면 말씀해주세요!

## ✨ 기타
