### PR TITLE
Refactor/#104 구글 소셜 로그인 URL 인코딩 버그 해결

### DIFF
--- a/src/main/java/com/ops/ops/global/util/oauth/component/GoogleOauth.java
+++ b/src/main/java/com/ops/ops/global/util/oauth/component/GoogleOauth.java
@@ -63,7 +63,6 @@ public class GoogleOauth implements SocialOauth {
                 .queryParam("response_type", "code")
                 .queryParam("client_id", GOOGLE_SNS_CLIENT_ID)
                 .queryParam("redirect_uri", callbackUrl)
-                .encode()
                 .build()
                 .toUriString();
     }


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #104 

## 📜 작업 내용

`GoogleOauth` 코드 내에 `UriComponentsBuilder.encode()`로 인해 URL 인코딩된 형태로 전달되는 것이 잘못되어 버그가 발생하였습니다.
 즉, Google Oauth가 기대하는 형태 
- 올바른 형태 : profile email (공백으로 구분되어있어야함!)
- encode를 통해 잘못된 형태 : profile$20email (url 인코딩된 형태) 

<img width="1174" height="475" alt="Image" src="https://github.com/user-attachments/assets/4f2a5cb1-c9ae-4ff5-8f2b-f089c79c7162" />

.encode()를 지워주니 해결되었습니다!

## 💬 리뷰 요구사항

없습니당!

## ✨ 기타
감사합니다!