### PR TITLE
Feature/#107 공지사항 응답 내용 추가

### DIFF
--- a/src/main/java/com/ops/ops/modules/notice/application/NoticeQueryService.java
+++ b/src/main/java/com/ops/ops/modules/notice/application/NoticeQueryService.java
@@ -27,7 +27,7 @@ public class NoticeQueryService {
     public List<NoticeSummaryResponse> getAllNotices() {
         return noticeRepository.findAllByOrderByCreatedAtDesc()
                 .stream()
-                .map(n -> new NoticeSummaryResponse(n.getId(), n.getTitle(), n.getUpdatedAt()))
+                .map(n -> new NoticeSummaryResponse(n.getId(), n.getTitle(), n.getCreatedAt()))
                 .toList();
     }
 }

--- a/src/main/java/com/ops/ops/modules/notice/application/NoticeQueryService.java
+++ b/src/main/java/com/ops/ops/modules/notice/application/NoticeQueryService.java
@@ -21,7 +21,8 @@ public class NoticeQueryService {
 
     public NoticeDetailResponse getNotice(final Long noticeId) {
         final Notice notice = noticeConvenience.getValidateExistNotice(noticeId);
-        return new NoticeDetailResponse(notice.getTitle(), notice.getDescription(), notice.getUpdatedAt());
+        return new NoticeDetailResponse(notice.getTitle(), notice.getDescription(), notice.getUpdatedAt(),
+                notice.getCreatedAt());
     }
 
     public List<NoticeSummaryResponse> getAllNotices() {

--- a/src/main/java/com/ops/ops/modules/notice/application/dto/response/NoticeDetailResponse.java
+++ b/src/main/java/com/ops/ops/modules/notice/application/dto/response/NoticeDetailResponse.java
@@ -6,6 +6,7 @@ public record NoticeDetailResponse(
 
         String title,
         String description,
-        LocalDateTime updatedAt
+        LocalDateTime updatedAt,
+        LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/com/ops/ops/modules/notice/application/dto/response/NoticeDetailResponse.java
+++ b/src/main/java/com/ops/ops/modules/notice/application/dto/response/NoticeDetailResponse.java
@@ -1,13 +1,11 @@
 package com.ops.ops.modules.notice.application.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 
 public record NoticeDetailResponse(
 
         String title,
         String description,
-        @JsonFormat(pattern = "yyyy년 MM월 dd일 EEEE HH:mm", locale  = "ko")
         LocalDateTime updatedAt
 ) {
 }

--- a/src/main/java/com/ops/ops/modules/notice/application/dto/response/NoticeSummaryResponse.java
+++ b/src/main/java/com/ops/ops/modules/notice/application/dto/response/NoticeSummaryResponse.java
@@ -6,6 +6,6 @@ public record NoticeSummaryResponse(
 
         Long noticeId,
         String title,
-        LocalDateTime updatedAt
+        LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/com/ops/ops/modules/notice/application/dto/response/NoticeSummaryResponse.java
+++ b/src/main/java/com/ops/ops/modules/notice/application/dto/response/NoticeSummaryResponse.java
@@ -1,13 +1,11 @@
 package com.ops.ops.modules.notice.application.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 
 public record NoticeSummaryResponse(
 
         Long noticeId,
         String title,
-        @JsonFormat(pattern = "yyyy년 MM월 dd일 EEEE HH:mm", locale  = "ko")
         LocalDateTime updatedAt
 ) {
 }


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #107 
close: #106 

## 📜 작업 내용

- 생성 시간과 수정 시간을 LocalDateTime으로 응답하도록 변경
- 공지사항 상세보기는 생성 시간, 수정 시간 모두 보내고, 공지사항 목록 조회는 수정 시간만 보내도록 수정

## 💬 리뷰 요구사항

- 없습니당!

## ✨ 기타

- 비가 오네요