### PR TITLE
Feature/#109 팀 정렬 방식 설정 api 개발

### DIFF
--- a/src/main/java/com/ops/ops/modules/contest/application/ContestQueryService.java
+++ b/src/main/java/com/ops/ops/modules/contest/application/ContestQueryService.java
@@ -9,8 +9,10 @@ import com.ops.ops.modules.contest.exception.ContestException;
 import com.ops.ops.modules.member.domain.Member;
 import com.ops.ops.modules.team.application.convenience.TeamConvenience;
 import com.ops.ops.modules.team.application.convenience.TeamLikeConvenience;
+import com.ops.ops.modules.team.application.convenience.TeamSortConvenience;
 import com.ops.ops.modules.team.application.dto.response.TeamSummaryResponse;
 import com.ops.ops.modules.team.domain.Team;
+import com.ops.ops.modules.team.domain.TeamSort;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,6 +27,7 @@ public class ContestQueryService {
 
     private final TeamConvenience teamConvenience;
     private final TeamLikeConvenience teamLikeConvenience;
+    private final TeamSortConvenience teamSortConvenience;
 
     public List<ContestResponse> getAllContests() {
         List<Contest> contests = contestRepository.findAll();
@@ -41,12 +44,14 @@ public class ContestQueryService {
 
     public List<TeamSummaryResponse> getContestTeamSummaries(final Long contestId, final Member member) {
         final List<Team> teams = teamConvenience.findAllByContestId(contestId);
-        return teamLikeConvenience.getAllTeamSummaries(teams, member);
+        final TeamSort teamSort = teamSortConvenience.getValidateExistTeamSort();
+        return teamLikeConvenience.getAllTeamSummaries(teams, member, teamSort.getMode());
     }
 
     public List<TeamSummaryResponse> getCurrentContestTeamSummaries(final Member member) {
         final List<Team> teams = findTeamsOfCurrentContest();
-        return teamLikeConvenience.getAllTeamSummaries(teams, member);
+        final TeamSort teamSort = teamSortConvenience.getValidateExistTeamSort();
+        return teamLikeConvenience.getAllTeamSummaries(teams, member, teamSort.getMode());
     }
 
     private List<Team> findTeamsOfCurrentContest() {

--- a/src/main/java/com/ops/ops/modules/team/api/TeamController.java
+++ b/src/main/java/com/ops/ops/modules/team/api/TeamController.java
@@ -11,6 +11,7 @@ import com.ops.ops.modules.team.application.TeamQueryService;
 import com.ops.ops.modules.team.application.dto.request.PreviewDeleteRequest;
 import com.ops.ops.modules.team.application.dto.request.TeamCreateRequest;
 import com.ops.ops.modules.team.application.dto.request.TeamDetailUpdateRequest;
+import com.ops.ops.modules.team.application.dto.request.TeamSortRequest;
 import com.ops.ops.modules.team.application.dto.response.TeamCreateResponse;
 import com.ops.ops.modules.team.application.dto.response.TeamDetailResponse;
 import com.ops.ops.modules.team.application.dto.response.TeamSubmissionStatusResponse;
@@ -166,5 +167,14 @@ public class TeamController {
     ) {
         TeamCreateResponse response = teamCommandService.createTeam(request);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "팀 정렬 변경", description = "팀 정렬 방식을 변경합니다. (ASC OR RANDOM)")
+    @ApiResponse(responseCode = "204", description = "팀 정렬 변경 성공")
+    @PatchMapping("/sort")
+    @Secured("ROLE_관리자")
+    public ResponseEntity<Void> updateTeamSort(@RequestBody @Valid final TeamSortRequest request) {
+        teamCommandService.updateTeamSort(request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
@@ -8,7 +8,6 @@ import static com.ops.ops.modules.file.domain.FileImageType.PREVIEW;
 import static com.ops.ops.modules.file.exception.FileExceptionType.EXCEED_PREVIEW_LIMIT;
 import static com.ops.ops.modules.member.domain.MemberRoleType.ROLE_관리자;
 import static com.ops.ops.modules.member.domain.MemberRoleType.ROLE_팀장;
-import static com.ops.ops.modules.team.exception.TeamExceptionType.EXIST_ONLY_ONE_ABOUT_TEAM_SORT;
 
 import com.ops.ops.global.util.FileStorageUtil;
 import com.ops.ops.modules.contest.application.convenience.ContestConvenience;
@@ -21,6 +20,7 @@ import com.ops.ops.modules.member.application.convenience.MemberConvenience;
 import com.ops.ops.modules.member.domain.Member;
 import com.ops.ops.modules.team.application.convenience.TeamConvenience;
 import com.ops.ops.modules.team.application.convenience.TeamMemberConvenience;
+import com.ops.ops.modules.team.application.convenience.TeamSortConvenience;
 import com.ops.ops.modules.team.application.dto.request.TeamCreateRequest;
 import com.ops.ops.modules.team.application.dto.request.TeamDetailUpdateRequest;
 import com.ops.ops.modules.team.application.dto.request.TeamSortRequest;
@@ -28,8 +28,6 @@ import com.ops.ops.modules.team.application.dto.response.TeamCreateResponse;
 import com.ops.ops.modules.team.domain.Team;
 import com.ops.ops.modules.team.domain.TeamSort;
 import com.ops.ops.modules.team.domain.dao.TeamRepository;
-import com.ops.ops.modules.team.domain.dao.TeamSortRepository;
-import com.ops.ops.modules.team.exception.TeamException;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -46,7 +44,6 @@ public class TeamCommandService {
     private final FileStorageUtil fileStorageUtil;
 
     private final TeamRepository teamRepository;
-    private final TeamSortRepository teamSortRepository;
 
     private final TeamMemberCommandService teamMemberCommandService;
 
@@ -54,6 +51,7 @@ public class TeamCommandService {
     private final TeamConvenience teamConvenience;
     private final TeamMemberConvenience teamMemberConvenience;
     private final MemberConvenience memberConvenience;
+    private final TeamSortConvenience teamSortConvenience;
 
     public void saveThumbnailImage(final Long teamId, final MultipartFile image, final FileImageType thumbnailType) {
         teamConvenience.validateExistTeam(teamId);
@@ -126,10 +124,8 @@ public class TeamCommandService {
     }
 
     public void updateTeamSort(final TeamSortRequest request) {
-        checkExistTeamSort();
-
-        final TeamSort teamSort = teamSortRepository.findById(1L)
-                .orElseThrow(() -> new TeamException(EXIST_ONLY_ONE_ABOUT_TEAM_SORT));
+        teamSortConvenience.validateExistTeamSort();
+        final TeamSort teamSort = teamSortConvenience.getValidateExistTeamSort();
 
         teamSort.updateSortType(request.mode());
     }
@@ -186,12 +182,6 @@ public class TeamCommandService {
     private void checkIsTeamCreatable(final Contest contest) {
         if (!contest.isTeamCreatable()) {
             throw new ContestException(CANNOT_CREATE_TEAM_OF_CURRENT_CONTEST);
-        }
-    }
-
-    private void checkExistTeamSort() {
-        if (!teamSortRepository.existsById(1L)) {
-            teamSortRepository.save(TeamSort.builder().build());
         }
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
@@ -8,6 +8,7 @@ import static com.ops.ops.modules.file.domain.FileImageType.PREVIEW;
 import static com.ops.ops.modules.file.exception.FileExceptionType.EXCEED_PREVIEW_LIMIT;
 import static com.ops.ops.modules.member.domain.MemberRoleType.ROLE_관리자;
 import static com.ops.ops.modules.member.domain.MemberRoleType.ROLE_팀장;
+import static com.ops.ops.modules.team.exception.TeamExceptionType.EXIST_ONLY_ONE_ABOUT_TEAM_SORT;
 
 import com.ops.ops.global.util.FileStorageUtil;
 import com.ops.ops.modules.contest.application.convenience.ContestConvenience;
@@ -22,9 +23,13 @@ import com.ops.ops.modules.team.application.convenience.TeamConvenience;
 import com.ops.ops.modules.team.application.convenience.TeamMemberConvenience;
 import com.ops.ops.modules.team.application.dto.request.TeamCreateRequest;
 import com.ops.ops.modules.team.application.dto.request.TeamDetailUpdateRequest;
+import com.ops.ops.modules.team.application.dto.request.TeamSortRequest;
 import com.ops.ops.modules.team.application.dto.response.TeamCreateResponse;
 import com.ops.ops.modules.team.domain.Team;
+import com.ops.ops.modules.team.domain.TeamSort;
 import com.ops.ops.modules.team.domain.dao.TeamRepository;
+import com.ops.ops.modules.team.domain.dao.TeamSortRepository;
+import com.ops.ops.modules.team.exception.TeamException;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +46,7 @@ public class TeamCommandService {
     private final FileStorageUtil fileStorageUtil;
 
     private final TeamRepository teamRepository;
+    private final TeamSortRepository teamSortRepository;
 
     private final TeamMemberCommandService teamMemberCommandService;
 
@@ -119,6 +125,15 @@ public class TeamCommandService {
         return TeamCreateResponse.from(team);
     }
 
+    public void updateTeamSort(final TeamSortRequest request) {
+        checkExistTeamSort();
+
+        final TeamSort teamSort = teamSortRepository.findById(1L)
+                .orElseThrow(() -> new TeamException(EXIST_ONLY_ONE_ABOUT_TEAM_SORT));
+
+        teamSort.updateSortType(request.mode());
+    }
+
     private void checkPreviewLimit(Long teamId, List<MultipartFile> images) {
         long savedCount = fileRepository.countByTeamIdAndType(teamId, PREVIEW);
         if (savedCount + images.size() > 5) {
@@ -171,6 +186,12 @@ public class TeamCommandService {
     private void checkIsTeamCreatable(final Contest contest) {
         if (!contest.isTeamCreatable()) {
             throw new ContestException(CANNOT_CREATE_TEAM_OF_CURRENT_CONTEST);
+        }
+    }
+
+    private void checkExistTeamSort() {
+        if (!teamSortRepository.existsById(1L)) {
+            teamSortRepository.save(TeamSort.builder().build());
         }
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/application/convenience/TeamLikeConvenience.java
+++ b/src/main/java/com/ops/ops/modules/team/application/convenience/TeamLikeConvenience.java
@@ -1,9 +1,11 @@
 package com.ops.ops.modules.team.application.convenience;
 
+import static com.ops.ops.modules.team.domain.SortType.RANDOM;
 import static java.util.stream.Collectors.toMap;
 
 import com.ops.ops.modules.member.domain.Member;
 import com.ops.ops.modules.team.application.dto.response.TeamSummaryResponse;
+import com.ops.ops.modules.team.domain.SortType;
 import com.ops.ops.modules.team.domain.Team;
 import com.ops.ops.modules.team.domain.TeamLike;
 import com.ops.ops.modules.team.domain.dao.TeamLikeRepository;
@@ -21,8 +23,9 @@ public class TeamLikeConvenience {
 
     private final TeamLikeRepository teamLikeRepository;
 
-    public List<TeamSummaryResponse> getAllTeamSummaries(final List<Team> teams, final Member member) {
-        Collections.shuffle(teams);
+    public List<TeamSummaryResponse> getAllTeamSummaries(final List<Team> teams, final Member member,
+                                                         final SortType mode) {
+        if (mode.equals(RANDOM)) Collections.shuffle(teams);
 
         final Map<Long, Boolean> likeMap =
                 (member != null) ? teamLikeRepository.findAllByMemberIdAndTeamIn(member.getId(), teams).stream()

--- a/src/main/java/com/ops/ops/modules/team/application/convenience/TeamSortConvenience.java
+++ b/src/main/java/com/ops/ops/modules/team/application/convenience/TeamSortConvenience.java
@@ -1,0 +1,28 @@
+package com.ops.ops.modules.team.application.convenience;
+
+import static com.ops.ops.modules.team.exception.TeamExceptionType.EXIST_ONLY_ONE_ABOUT_TEAM_SORT;
+
+import com.ops.ops.modules.team.domain.TeamSort;
+import com.ops.ops.modules.team.domain.dao.TeamSortRepository;
+import com.ops.ops.modules.team.exception.TeamException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeamSortConvenience {
+
+    private final TeamSortRepository teamSortRepository;
+
+    public void validateExistTeamSort() {
+        if (!teamSortRepository.existsById(1L)) {
+            teamSortRepository.save(TeamSort.builder().build());
+        }
+    }
+
+    public TeamSort getValidateExistTeamSort() {
+        return teamSortRepository.findById(1L).orElseThrow(() -> new TeamException(EXIST_ONLY_ONE_ABOUT_TEAM_SORT));
+    }
+}

--- a/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamSortRequest.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamSortRequest.java
@@ -1,0 +1,10 @@
+package com.ops.ops.modules.team.application.dto.request;
+
+import com.ops.ops.modules.team.domain.SortType;
+import jakarta.validation.constraints.NotNull;
+
+public record TeamSortRequest(
+        @NotNull(message = "모드를 입력하세요.")
+        SortType mode
+) {
+}

--- a/src/main/java/com/ops/ops/modules/team/domain/SortType.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/SortType.java
@@ -1,0 +1,6 @@
+package com.ops.ops.modules.team.domain;
+
+public enum SortType {
+    ASC,
+    RANDOM
+}

--- a/src/main/java/com/ops/ops/modules/team/domain/TeamSort.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/TeamSort.java
@@ -1,0 +1,38 @@
+package com.ops.ops.modules.team.domain;
+
+import static com.ops.ops.modules.team.domain.SortType.RANDOM;
+
+import com.ops.ops.global.base.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class TeamSort extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SortType mode = RANDOM;
+
+    public void updateSortType(final SortType updateMode) {
+        this.mode = updateMode;
+    }
+}

--- a/src/main/java/com/ops/ops/modules/team/domain/dao/TeamSortRepository.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/dao/TeamSortRepository.java
@@ -1,0 +1,7 @@
+package com.ops.ops.modules.team.domain.dao;
+
+import com.ops.ops.modules.team.domain.TeamSort;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamSortRepository extends JpaRepository<TeamSort, Long> {
+}

--- a/src/main/java/com/ops/ops/modules/team/exception/TeamExceptionType.java
+++ b/src/main/java/com/ops/ops/modules/team/exception/TeamExceptionType.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 public enum TeamExceptionType implements BaseExceptionType {
     NOT_FOUND_TEAM(HttpStatus.NOT_FOUND, "팀을 찾을 수 없습니다."),
     NOT_TEAM_LEADER(HttpStatus.FORBIDDEN, "해당 팀의 팀장 권한이 없습니다."),
+    EXIST_ONLY_ONE_ABOUT_TEAM_SORT(HttpStatus.NOT_FOUND, "팀 정렬 테이블의 id는 1번만 존재합니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #109

## 📜 작업 내용

- 팀 정렬 방식 설정 API를 구현했습니다! (정렬 DEFAULT는 RANDOM 입니다)

## 💬 리뷰 요구사항

- 팀 정렬 방식은 관리자가 변경하기 전까지 전역적으로 유지되어야 합니다. 재배포 시에도 유지되어야 하고요.
- 설정 정보를 저장하는 방법으로 테이블 추가가 가장 간단할 것 같아 `TeamSort` 테이블을 추가했습니다.
  - `TeamSort` 테이블은 **오직 1개의 레코드**를 가지고 있습니다. **(생성은 따로 없고 수정 시 id = 1L이 없으면 생성 -> 그 이후 1L 만 조회해서 수정)**

## ✨ 기타

- 더 좋은 의견 있으면 추천해주세용