### PR TITLE
fix : 투표참여율 분모값에서 가짜멤버 빼기

### DIFF
--- a/src/main/java/com/ops/ops/modules/member/application/convenience/MemberConvenience.java
+++ b/src/main/java/com/ops/ops/modules/member/application/convenience/MemberConvenience.java
@@ -12,12 +12,15 @@ import com.ops.ops.modules.member.domain.MemberRoleType;
 import com.ops.ops.modules.member.domain.dao.MemberRepository;
 import com.ops.ops.modules.member.exception.EmailAuthException;
 import com.ops.ops.modules.member.exception.MemberException;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -73,7 +76,9 @@ public class MemberConvenience {
     }
 
     public long countTotalMember() {
-        return memberRepository.count();
+        return memberRepository.findAll().stream()
+                .filter(member -> !Member.isFake(member))
+                .count();
     }
 
     public List<Member> findAllById(final List<Long> memberIds) {

--- a/src/main/java/com/ops/ops/modules/member/domain/Member.java
+++ b/src/main/java/com/ops/ops/modules/member/domain/Member.java
@@ -3,6 +3,7 @@ package com.ops.ops.modules.member.domain;
 import static com.ops.ops.modules.member.domain.MemberRoleType.ROLE_회원;
 
 import com.ops.ops.global.base.BaseEntity;
+
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
@@ -14,14 +15,17 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import java.util.HashSet;
-import java.util.Set;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
+
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -82,7 +86,7 @@ public class Member extends BaseEntity {
     }
 
     public static boolean isFake(Member member) {
-        return member.getEmail() != null && member.getStudentId().startsWith("fake_");
+        return member.getEmail().startsWith("fake_") && member.getStudentId().startsWith("fake_");
     }
 
     public boolean isTeamLeader() {


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #113 

## 📜 작업 내용

 해당 투표 참여율 계산 공식은 다음과 같습니다.

<img width="464" height="64" alt="Image" src="https://github.com/user-attachments/assets/11c04d6f-432e-4e3f-9914-2ec90582afc0" />

 프로젝트에 팀원을 추가하면 해당 팀원의 이름으로 가짜 회원이 생성되기 때문에 투표 참여율 계산 공식의 분모 부분이 커져 저희가 예상했던 것과는 다르게 계산되었습니다.

따라서 가짜회원의 경우 투표 기능이 없기에 회원 안에 포함되지 않도록 필터링하였습니다-!

⭐️ 추가적으로 `Member` 엔티티의 `isFake`메서드의 경우 구글 소셜 로그인으로 가입한 사용자 또한 가짜 멤버가 되기에 이메일까지 추가적으로 검증하여 팀원 추가를 통한 가짜멤버만 `isFake`로 인식하도록 여원님께 허락 받고 수정하였습니다!

## 💬 리뷰 요구사항

따로 없습니다!

## ✨ 기타
감사합니다!
