### PR TITLE
Feature/#119 투표 on,off 기능추가

### DIFF
--- a/src/main/java/com/ops/ops/modules/contest/api/ContestController.java
+++ b/src/main/java/com/ops/ops/modules/contest/api/ContestController.java
@@ -6,6 +6,7 @@ import com.ops.ops.global.security.annotation.LoginMember;
 import com.ops.ops.modules.contest.application.ContestCommandService;
 import com.ops.ops.modules.contest.application.ContestQueryService;
 import com.ops.ops.modules.contest.application.dto.request.ContestRequest;
+import com.ops.ops.modules.contest.application.dto.request.VoteUpdateRequest;
 import com.ops.ops.modules.contest.application.dto.response.ContestResponse;
 import com.ops.ops.modules.member.domain.Member;
 import com.ops.ops.modules.team.application.dto.response.TeamSummaryResponse;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -96,5 +98,15 @@ public class ContestController {
     ) {
         List<TeamSummaryResponse> responses = contestQueryService.getCurrentContestTeamSummaries(member);
         return ResponseEntity.ok(responses);
+    }
+
+    @Operation(summary = "특정 대회 투표 기간 수정", description = "해당 대회의 투표 기간을 수정합니다.")
+    @ApiResponse(responseCode = "200", description = "대회의 투표 기간 수정 성공")
+    @Secured("ROLE_관리자")
+    @PutMapping("/{contestId}/vote")
+    public ResponseEntity<Void> updateVotePeriod(@PathVariable final Long contestId,
+                                                 @Valid @RequestBody final VoteUpdateRequest voteRequest) {
+        contestCommandService.updateVotePeriod(contestId, voteRequest);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/ops/ops/modules/contest/api/ContestController.java
+++ b/src/main/java/com/ops/ops/modules/contest/api/ContestController.java
@@ -8,6 +8,7 @@ import com.ops.ops.modules.contest.application.ContestQueryService;
 import com.ops.ops.modules.contest.application.dto.request.ContestRequest;
 import com.ops.ops.modules.contest.application.dto.request.VoteUpdateRequest;
 import com.ops.ops.modules.contest.application.dto.response.ContestResponse;
+import com.ops.ops.modules.contest.application.dto.response.VoteResponse;
 import com.ops.ops.modules.member.domain.Member;
 import com.ops.ops.modules.team.application.dto.response.TeamSummaryResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -108,5 +109,12 @@ public class ContestController {
                                                  @Valid @RequestBody final VoteUpdateRequest voteRequest) {
         contestCommandService.updateVotePeriod(contestId, voteRequest);
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "특정 대회 투표 기간 조회", description = "해당 대회의 투표 기간을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "대회의 투표 기간 조회 성공")
+    @GetMapping("/{contestId}/vote")
+    public ResponseEntity<VoteResponse> getVotePeriod(@PathVariable final Long contestId) {
+        return ResponseEntity.ok(contestQueryService.getVotePeriod(contestId));
     }
 }

--- a/src/main/java/com/ops/ops/modules/contest/application/ContestCommandService.java
+++ b/src/main/java/com/ops/ops/modules/contest/application/ContestCommandService.java
@@ -1,8 +1,11 @@
 package com.ops.ops.modules.contest.application;
 
 import com.ops.ops.modules.contest.application.convenience.ContestConvenience;
+import com.ops.ops.modules.contest.application.dto.request.VoteUpdateRequest;
 import com.ops.ops.modules.contest.domain.Contest;
 import com.ops.ops.modules.contest.domain.dao.ContestRepository;
+import com.ops.ops.modules.contest.exception.ContestException;
+import com.ops.ops.modules.contest.exception.ContestExceptionType;
 import com.ops.ops.modules.team.application.convenience.TeamConvenience;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -38,5 +41,18 @@ public class ContestCommandService {
         final Contest contest = contestConvenience.getValidateExistContest(contestId);
         teamConvenience.checkAllContestDelete(contestId);
         contestRepository.delete(contest);
+    }
+
+    public void updateVotePeriod(Long contestId, VoteUpdateRequest voteRequest) {
+        final Contest contest = contestConvenience.getValidateExistContest(contestId);
+        checkVoteRange(voteRequest);
+        contest.updateVotePeriod(voteRequest.voteStartAt(), voteRequest.voteEndAt());
+    }
+
+    private void checkVoteRange(VoteUpdateRequest voteRequest) {
+        int compare = voteRequest.voteStartAt().compareTo(voteRequest.voteEndAt());
+        if (compare > 0) {
+            throw new ContestException(ContestExceptionType.VOTE_END_PRECEDE_VOTE_START);
+        }
     }
 }

--- a/src/main/java/com/ops/ops/modules/contest/application/ContestQueryService.java
+++ b/src/main/java/com/ops/ops/modules/contest/application/ContestQueryService.java
@@ -2,7 +2,9 @@ package com.ops.ops.modules.contest.application;
 
 import static com.ops.ops.modules.contest.exception.ContestExceptionType.NOT_FOUND_CURRENT_CONTEST;
 
+import com.ops.ops.modules.contest.application.convenience.ContestConvenience;
 import com.ops.ops.modules.contest.application.dto.response.ContestResponse;
+import com.ops.ops.modules.contest.application.dto.response.VoteResponse;
 import com.ops.ops.modules.contest.domain.Contest;
 import com.ops.ops.modules.contest.domain.dao.ContestRepository;
 import com.ops.ops.modules.contest.exception.ContestException;
@@ -28,6 +30,7 @@ public class ContestQueryService {
     private final TeamConvenience teamConvenience;
     private final TeamLikeConvenience teamLikeConvenience;
     private final TeamSortConvenience teamSortConvenience;
+    private final ContestConvenience contestConvenience;
 
     public List<ContestResponse> getAllContests() {
         List<Contest> contests = contestRepository.findAll();
@@ -58,5 +61,10 @@ public class ContestQueryService {
         final Contest contest = contestRepository.findByIsCurrentTrue()
                 .orElseThrow(() -> new ContestException(NOT_FOUND_CURRENT_CONTEST));
         return teamConvenience.findAllByContestId(contest.getId());
+    }
+
+    public VoteResponse getVotePeriod(Long contestId) {
+        final Contest contest = contestConvenience.getValidateExistContest(contestId);
+        return new VoteResponse(contest.getVoteStartAt(), contest.getVoteEndAt());
     }
 }

--- a/src/main/java/com/ops/ops/modules/contest/application/convenience/ContestConvenience.java
+++ b/src/main/java/com/ops/ops/modules/contest/application/convenience/ContestConvenience.java
@@ -3,10 +3,12 @@ package com.ops.ops.modules.contest.application.convenience;
 import static com.ops.ops.modules.contest.exception.ContestExceptionType.CANNOT_UPDATE_TEAM_INFO_FOR_CURRENT;
 import static com.ops.ops.modules.contest.exception.ContestExceptionType.CONTEST_NAME_ALREADY_EXIST;
 import static com.ops.ops.modules.contest.exception.ContestExceptionType.NOT_FOUND_CONTEST;
+import static com.ops.ops.modules.contest.exception.ContestExceptionType.NOT_VOTE_PERIOD_NOW;
 
 import com.ops.ops.modules.contest.domain.Contest;
 import com.ops.ops.modules.contest.domain.dao.ContestRepository;
 import com.ops.ops.modules.contest.exception.ContestException;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +37,13 @@ public class ContestConvenience {
     public void checkDuplicateContestName(String contestName) {
         if (contestRepository.existsByContestName(contestName)) {
             throw new ContestException(CONTEST_NAME_ALREADY_EXIST);
+        }
+    }
+
+    public void checkVotePeriodNow(Long contestId, LocalDateTime now) {
+        Contest contest = getValidateExistContest(contestId);
+        if (!(now.isAfter(contest.getVoteStartAt()) && now.isBefore(contest.getVoteEndAt()))) {
+            throw new ContestException(NOT_VOTE_PERIOD_NOW);
         }
     }
 }

--- a/src/main/java/com/ops/ops/modules/contest/application/dto/request/VoteUpdateRequest.java
+++ b/src/main/java/com/ops/ops/modules/contest/application/dto/request/VoteUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.ops.ops.modules.contest.application.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import java.time.LocalDateTime;
+
+public record VoteUpdateRequest(
+        @NotEmpty(message = "투표 시작 시각을 정해야 합니다")
+        LocalDateTime voteStartAt,
+        @NotEmpty(message = "투표 종료 시각을 정해야 합니다")
+        LocalDateTime voteEndAt
+) {
+}

--- a/src/main/java/com/ops/ops/modules/contest/application/dto/response/VoteResponse.java
+++ b/src/main/java/com/ops/ops/modules/contest/application/dto/response/VoteResponse.java
@@ -1,0 +1,9 @@
+package com.ops.ops.modules.contest.application.dto.response;
+
+import java.time.LocalDateTime;
+
+public record VoteResponse(
+        LocalDateTime voteStartAt,
+        LocalDateTime voteEndAt
+) {
+}

--- a/src/main/java/com/ops/ops/modules/contest/domain/Contest.java
+++ b/src/main/java/com/ops/ops/modules/contest/domain/Contest.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,11 +33,24 @@ public class Contest extends BaseEntity {
     @Column(nullable = false)
     private Boolean isDeleted;
 
+    @Column(nullable = false)
+    private LocalDateTime voteStartAt;
+
+    @Column(nullable = false)
+    private LocalDateTime voteEndAt;
+
     @Builder
     public Contest(final String contestName, final Boolean isCurrent) {
         this.contestName = contestName;
         this.isCurrent = isCurrent;
         this.isDeleted = false;
+        this.voteStartAt = LocalDateTime.now();
+        this.voteEndAt = LocalDateTime.now();
+    }
+
+    public void updateVotePeriod(final LocalDateTime voteStartAt, final LocalDateTime voteEndAt) {
+        this.voteStartAt = voteStartAt;
+        this.voteEndAt = voteEndAt;
     }
 
     public void updateContestName(final String newContestName) {

--- a/src/main/java/com/ops/ops/modules/contest/exception/ContestExceptionType.java
+++ b/src/main/java/com/ops/ops/modules/contest/exception/ContestExceptionType.java
@@ -11,7 +11,9 @@ public enum ContestExceptionType implements BaseExceptionType {
     CANNOT_CHANGE_CONTEST_FOR_CURRENT(HttpStatus.FORBIDDEN, "현재 진행 중인 대회의 팀의 대회를 수정할 수 없습니다."),
     CANNOT_UPDATE_TEAM_INFO_FOR_CURRENT(HttpStatus.FORBIDDEN, "현재 진행 중인 대회의 팀의 팀명, 프로젝트명, 팀장, 팀원 정보를 수정할 수 없습니다."),
     ADMIN_ONLY_FOR_PAST_CONTEST(HttpStatus.FORBIDDEN, "관리자만 과거 대회의 정보를 수정할 수 있습니다."),
-    CANNOT_CREATE_TEAM_OF_CURRENT_CONTEST(HttpStatus.FORBIDDEN, "현재 진행 중인 대회의 새로운 대회를 생성할 수 없습니다.");
+    CANNOT_CREATE_TEAM_OF_CURRENT_CONTEST(HttpStatus.FORBIDDEN, "현재 진행 중인 대회의 새로운 대회를 생성할 수 없습니다."),
+    VOTE_END_PRECEDE_VOTE_START(HttpStatus.BAD_REQUEST, "투표 종료가 투표 시작보다 빠를 수 없습니다.")
+    ;
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/com/ops/ops/modules/contest/exception/ContestExceptionType.java
+++ b/src/main/java/com/ops/ops/modules/contest/exception/ContestExceptionType.java
@@ -12,7 +12,8 @@ public enum ContestExceptionType implements BaseExceptionType {
     CANNOT_UPDATE_TEAM_INFO_FOR_CURRENT(HttpStatus.FORBIDDEN, "현재 진행 중인 대회의 팀의 팀명, 프로젝트명, 팀장, 팀원 정보를 수정할 수 없습니다."),
     ADMIN_ONLY_FOR_PAST_CONTEST(HttpStatus.FORBIDDEN, "관리자만 과거 대회의 정보를 수정할 수 있습니다."),
     CANNOT_CREATE_TEAM_OF_CURRENT_CONTEST(HttpStatus.FORBIDDEN, "현재 진행 중인 대회의 새로운 대회를 생성할 수 없습니다."),
-    VOTE_END_PRECEDE_VOTE_START(HttpStatus.BAD_REQUEST, "투표 종료가 투표 시작보다 빠를 수 없습니다.")
+    VOTE_END_PRECEDE_VOTE_START(HttpStatus.BAD_REQUEST, "투표 종료가 투표 시작보다 빠를 수 없습니다."),
+    NOT_VOTE_PERIOD_NOW(HttpStatus.BAD_REQUEST, "지금은 투표 기간이 아닙니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/ops/ops/modules/team/application/TeamLikeCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamLikeCommandService.java
@@ -1,6 +1,8 @@
 package com.ops.ops.modules.team.application;
 
+import com.ops.ops.modules.contest.application.convenience.ContestConvenience;
 import com.ops.ops.modules.team.application.convenience.TeamConvenience;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
@@ -19,11 +21,12 @@ import lombok.RequiredArgsConstructor;
 public class TeamLikeCommandService {
 
 	private final TeamLikeRepository teamLikeRepository;
-
 	private final TeamConvenience teamConvenience;
+	private final ContestConvenience contestConvenience;
 
 	public TeamLikeToggleResponse toggleLike(Long memberId, Long teamId, Boolean isLiked) {
 		Team team = teamConvenience.getValidateExistTeam(teamId);
+		contestConvenience.checkVotePeriodNow(team.getContestId(), LocalDateTime.now());
 
 		Optional<TeamLike> teamLikeOptional = teamLikeRepository.findByMemberIdAndTeam(memberId, team);
 		if (teamLikeOptional.isEmpty()) {


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #119 

## 📜 작업 내용

> 대회 테이블에 투표 시작/종료 시각 컬럼을 추가했습니다
> 대회별 투표 시작/종료 시각을 조회/수정할 수 있습니다

## 💬 리뷰 요구사항

> 투표 시각 관련으로 필요해 보이는 검증이 있다면 리뷰 부탁드립니다~
> 현재는 투표 종료 시각이 시작 시각을 앞설 수 없는 것만 확인합니다.

## ✨ 기타
