### PR TITLE
Feature/#125_팀-랜덤-조회-시-유저별-순서-고정

### DIFF
--- a/src/main/java/com/ops/ops/modules/team/application/convenience/TeamLikeConvenience.java
+++ b/src/main/java/com/ops/ops/modules/team/application/convenience/TeamLikeConvenience.java
@@ -12,6 +12,7 @@ import com.ops.ops.modules.team.domain.dao.TeamLikeRepository;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,7 +26,14 @@ public class TeamLikeConvenience {
 
     public List<TeamSummaryResponse> getAllTeamSummaries(final List<Team> teams, final Member member,
                                                          final SortType mode) {
-        if (mode.equals(RANDOM)) Collections.shuffle(teams);
+        if (mode.equals(RANDOM)) {
+            if (member != null) {
+                Random seed = new Random(member.getId());
+                Collections.shuffle(teams, seed);
+            } else {
+                Collections.shuffle(teams);
+            }
+        }
 
         final Map<Long, Boolean> likeMap =
                 (member != null) ? teamLikeRepository.findAllByMemberIdAndTeamIn(member.getId(), teams).stream()


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #125 

## 📜 작업 내용

> 메인화면에서 전체 팀을 랜덤으로 조회할 때,
시드를 이용해 유저 별로 랜덤의 순서를 고정하도록 하였습니다.

## 💬 리뷰 요구사항

>

## ✨ 기타
