### PR TITLE
Feature/#128 수상 설정 api개발

### DIFF
--- a/src/main/java/com/ops/ops/global/error/ExceptionAdvice.java
+++ b/src/main/java/com/ops/ops/global/error/ExceptionAdvice.java
@@ -27,8 +27,11 @@ public class ExceptionAdvice {
     private static String getErrorMessage(final BindException e) {
         final BindingResult bindingResult = e.getBindingResult();
         return bindingResult.getFieldErrors().stream()
-                .map(fieldError -> getErrorMessage(fieldError.getField(), (String) fieldError.getRejectedValue(),
-                        fieldError.getDefaultMessage())).collect(Collectors.joining(", "));
+                .map(fieldError -> {
+                    assert fieldError.getRejectedValue() != null;
+                    return getErrorMessage(fieldError.getField(), fieldError.getRejectedValue().toString(),
+                            fieldError.getDefaultMessage());
+                }).collect(Collectors.joining(", "));
     }
 
     private static String getErrorMessage(final String errorField, final String invalidValue,

--- a/src/main/java/com/ops/ops/modules/team/api/TeamAdminController.java
+++ b/src/main/java/com/ops/ops/modules/team/api/TeamAdminController.java
@@ -1,19 +1,28 @@
 package com.ops.ops.modules.team.api;
 
 import com.ops.ops.modules.team.application.TeamAdminQueryService;
+import com.ops.ops.modules.team.application.TeamCommandService;
+import com.ops.ops.modules.team.application.dto.request.TeamAwardRequest;
 import com.ops.ops.modules.team.application.dto.response.TeamLikeRankingResponse;
 import com.ops.ops.modules.team.application.dto.response.TeamSubmissionStatusResponse;
 import com.ops.ops.modules.team.application.dto.response.TeamVoteRateResponse;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @Tag(name = "Team Admin", description = "팀 관리 기능 (관리자 전용)")
 @RestController
@@ -22,26 +31,38 @@ import org.springframework.web.bind.annotation.RestController;
 @Secured("ROLE_관리자")
 public class TeamAdminController {
 
-	private final TeamAdminQueryService teamAdminQueryService;
+    private final TeamAdminQueryService teamAdminQueryService;
+    private final TeamCommandService teamCommandService;
 
-	@Operation(summary = "전체 팀 등록 현황 조회", description = "관리자가 모든 팀의 제출 여부를 포함한 현황을 조회합니다.")
-	@ApiResponse(responseCode = "200", description = "조회 성공")
-	@GetMapping("/dashboard")
-	public ResponseEntity<List<TeamSubmissionStatusResponse>> getAllTeamSubmissions() {
-		return ResponseEntity.ok(teamAdminQueryService.getAllTeamSubmissions());
-	}
+    @Operation(summary = "전체 팀 등록 현황 조회", description = "관리자가 모든 팀의 제출 여부를 포함한 현황을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/dashboard")
+    public ResponseEntity<List<TeamSubmissionStatusResponse>> getAllTeamSubmissions() {
+        return ResponseEntity.ok(teamAdminQueryService.getAllTeamSubmissions());
+    }
 
-	@Operation(summary = "좋아요 랭킹 조회", description = "좋아요 수 기준으로 팀 랭킹을 조회합니다. (Competition Ranking 방식)")
-	@ApiResponse(responseCode = "200", description = "조회 성공")
-	@GetMapping("/ranking")
-	public ResponseEntity<List<TeamLikeRankingResponse>> getTeamLikeRanking() {
-		return ResponseEntity.ok(teamAdminQueryService.getTeamLikeRanking());
-	}
+    @Operation(
+            summary = "좋아요 랭킹 조회",
+            description = "좋아요 수 기준으로 팀 랭킹을 조회합니다. (Competition Ranking 방식)")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/ranking")
+    public ResponseEntity<List<TeamLikeRankingResponse>> getTeamLikeRanking() {
+        return ResponseEntity.ok(teamAdminQueryService.getTeamLikeRanking());
+    }
 
-	@Operation(summary = "투표 참여율 조회", description = "전체 팀의 좋아요 수를 기반으로 투표 참여율을 계산하여 반환합니다.")
-	@ApiResponse(responseCode = "200", description = "조회 성공")
-	@GetMapping("/participation-rate")
-	public ResponseEntity<TeamVoteRateResponse> getTeamParticipationRate() {
-		return ResponseEntity.ok(teamAdminQueryService.getVoteRate());
-	}
+    @Operation(summary = "투표 참여율 조회", description = "전체 팀의 좋아요 수를 기반으로 투표 참여율을 계산하여 반환합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/participation-rate")
+    public ResponseEntity<TeamVoteRateResponse> getTeamParticipationRate() {
+        return ResponseEntity.ok(teamAdminQueryService.getVoteRate());
+    }
+
+    @Operation(summary = "팀 수상 설정", description = "관리자가 특정 팀의 상훈명을 등록합니다.")
+    @ApiResponse(responseCode = "200", description = "설정 성공")
+    @PostMapping("/teams/{teamId}/award")
+    public ResponseEntity<Void> updateTeamAward(
+            @PathVariable final Long teamId, @RequestBody final TeamAwardRequest teamAwardRequest) {
+        teamCommandService.updateAwardName(teamId, teamAwardRequest.awardName());
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/ops/ops/modules/team/api/TeamAdminController.java
+++ b/src/main/java/com/ops/ops/modules/team/api/TeamAdminController.java
@@ -62,7 +62,8 @@ public class TeamAdminController {
     @PostMapping("/teams/{teamId}/award")
     public ResponseEntity<Void> updateTeamAward(
             @PathVariable final Long teamId, @RequestBody final TeamAwardRequest teamAwardRequest) {
-        teamCommandService.updateAwardName(teamId, teamAwardRequest.awardName());
+        teamCommandService.updateAwardName(
+                teamId, teamAwardRequest.awardName(), teamAwardRequest.awardColor());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/api/TeamAdminController.java
+++ b/src/main/java/com/ops/ops/modules/team/api/TeamAdminController.java
@@ -9,6 +9,7 @@ import com.ops.ops.modules.team.application.dto.response.TeamVoteRateResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -55,7 +56,7 @@ public class TeamAdminController {
     @ApiResponse(responseCode = "204", description = "팀 수상 설정 성공")
     @PatchMapping("/teams/{teamId}/award")
     public ResponseEntity<Void> updateTeamAward(@PathVariable final Long teamId,
-                                                @RequestBody final TeamAwardRequest teamAwardRequest) {
+                                                @Valid @RequestBody final TeamAwardRequest teamAwardRequest) {
         teamAdminCommandService.updateAward(teamId, teamAwardRequest.awardName(), teamAwardRequest.awardColor());
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/ops/ops/modules/team/api/TeamAdminController.java
+++ b/src/main/java/com/ops/ops/modules/team/api/TeamAdminController.java
@@ -1,28 +1,24 @@
 package com.ops.ops.modules.team.api;
 
+import com.ops.ops.modules.team.application.TeamAdminCommandService;
 import com.ops.ops.modules.team.application.TeamAdminQueryService;
-import com.ops.ops.modules.team.application.TeamCommandService;
 import com.ops.ops.modules.team.application.dto.request.TeamAwardRequest;
 import com.ops.ops.modules.team.application.dto.response.TeamLikeRankingResponse;
 import com.ops.ops.modules.team.application.dto.response.TeamSubmissionStatusResponse;
 import com.ops.ops.modules.team.application.dto.response.TeamVoteRateResponse;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @Tag(name = "Team Admin", description = "팀 관리 기능 (관리자 전용)")
 @RestController
@@ -32,7 +28,7 @@ import java.util.List;
 public class TeamAdminController {
 
     private final TeamAdminQueryService teamAdminQueryService;
-    private final TeamCommandService teamCommandService;
+    private final TeamAdminCommandService teamAdminCommandService;
 
     @Operation(summary = "전체 팀 등록 현황 조회", description = "관리자가 모든 팀의 제출 여부를 포함한 현황을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공")
@@ -58,12 +54,11 @@ public class TeamAdminController {
     }
 
     @Operation(summary = "팀 수상 설정", description = "관리자가 특정 팀의 상훈명을 등록합니다.")
-    @ApiResponse(responseCode = "200", description = "설정 성공")
-    @PostMapping("/teams/{teamId}/award")
+    @ApiResponse(responseCode = "204", description = "팀 수상 설정 성공")
+    @PatchMapping("/teams/{teamId}/award")
     public ResponseEntity<Void> updateTeamAward(
             @PathVariable final Long teamId, @RequestBody final TeamAwardRequest teamAwardRequest) {
-        teamCommandService.updateAwardName(
-                teamId, teamAwardRequest.awardName(), teamAwardRequest.awardColor());
+        teamAdminCommandService.updateAward(teamId, teamAwardRequest.awardName(), teamAwardRequest.awardColor());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/api/TeamAdminController.java
+++ b/src/main/java/com/ops/ops/modules/team/api/TeamAdminController.java
@@ -37,9 +37,7 @@ public class TeamAdminController {
         return ResponseEntity.ok(teamAdminQueryService.getAllTeamSubmissions());
     }
 
-    @Operation(
-            summary = "좋아요 랭킹 조회",
-            description = "좋아요 수 기준으로 팀 랭킹을 조회합니다. (Competition Ranking 방식)")
+    @Operation(summary = "좋아요 랭킹 조회", description = "좋아요 수 기준으로 팀 랭킹을 조회합니다. (Competition Ranking 방식)")
     @ApiResponse(responseCode = "200", description = "조회 성공")
     @GetMapping("/ranking")
     public ResponseEntity<List<TeamLikeRankingResponse>> getTeamLikeRanking() {
@@ -56,8 +54,8 @@ public class TeamAdminController {
     @Operation(summary = "팀 수상 설정", description = "관리자가 특정 팀의 상훈명을 등록합니다.")
     @ApiResponse(responseCode = "204", description = "팀 수상 설정 성공")
     @PatchMapping("/teams/{teamId}/award")
-    public ResponseEntity<Void> updateTeamAward(
-            @PathVariable final Long teamId, @RequestBody final TeamAwardRequest teamAwardRequest) {
+    public ResponseEntity<Void> updateTeamAward(@PathVariable final Long teamId,
+                                                @RequestBody final TeamAwardRequest teamAwardRequest) {
         teamAdminCommandService.updateAward(teamId, teamAwardRequest.awardName(), teamAwardRequest.awardColor());
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/ops/ops/modules/team/application/TeamAdminCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamAdminCommandService.java
@@ -1,12 +1,7 @@
 package com.ops.ops.modules.team.application;
 
-import static com.ops.ops.modules.team.exception.TeamExceptionType.INVALID_AWARD_PARAMETERS;
-import static com.ops.ops.modules.team.exception.TeamExceptionType.INVALID_COLOR_FORMAT;
-
 import com.ops.ops.modules.team.application.convenience.TeamConvenience;
 import com.ops.ops.modules.team.domain.Team;
-import com.ops.ops.modules.team.exception.TeamException;
-import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,30 +13,8 @@ public class TeamAdminCommandService {
 
     private final TeamConvenience teamConvenience;
 
-    private static final Pattern HEX_COLOR_PATTERN = Pattern.compile("^#[A-Fa-f0-9]{6}$");
-
     public void updateAward(final Long teamId, final String awardName, final String awardColor) {
-        validateAwardParameters(awardName, awardColor);
         final Team team = teamConvenience.getValidateExistTeam(teamId);
         team.updateAward(awardName, awardColor);
-    }
-
-    private void validateAwardParameters(final String awardName, final String awardColor) {
-        if (awardName == null && awardColor == null) {
-            return;
-        }
-
-        if (awardName != null && awardColor != null && !awardName.trim().isEmpty() && !awardColor.trim().isEmpty()) {
-            validateColorFormat(awardColor);
-            return;
-        }
-
-        throw new TeamException(INVALID_AWARD_PARAMETERS);
-    }
-
-    private void validateColorFormat(final String awardColor) {
-        if (!HEX_COLOR_PATTERN.matcher(awardColor.trim()).matches()) {
-            throw new TeamException(INVALID_COLOR_FORMAT);
-        }
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/application/TeamAdminCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamAdminCommandService.java
@@ -1,0 +1,47 @@
+package com.ops.ops.modules.team.application;
+
+import static com.ops.ops.modules.team.exception.TeamExceptionType.INVALID_AWARD_PARAMETERS;
+import static com.ops.ops.modules.team.exception.TeamExceptionType.INVALID_COLOR_FORMAT;
+
+import com.ops.ops.modules.team.application.convenience.TeamConvenience;
+import com.ops.ops.modules.team.domain.Team;
+import com.ops.ops.modules.team.exception.TeamException;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TeamAdminCommandService {
+
+    private final TeamConvenience teamConvenience;
+
+    private static final Pattern HEX_COLOR_PATTERN = Pattern.compile("^#[A-Fa-f0-9]{6}$");
+
+    public void updateAward(final Long teamId, final String awardName, final String awardColor) {
+        validateAwardParameters(awardName, awardColor);
+        final Team team = teamConvenience.getValidateExistTeam(teamId);
+        team.updateAward(awardName, awardColor);
+    }
+
+    private void validateAwardParameters(final String awardName, final String awardColor) {
+        if (awardName == null && awardColor == null) {
+            return;
+        }
+
+        if (awardName != null && awardColor != null && !awardName.trim().isEmpty() && !awardColor.trim().isEmpty()) {
+            validateColorFormat(awardColor);
+            return;
+        }
+
+        throw new TeamException(INVALID_AWARD_PARAMETERS);
+    }
+
+    private void validateColorFormat(final String awardColor) {
+        if (!HEX_COLOR_PATTERN.matcher(awardColor.trim()).matches()) {
+            throw new TeamException(INVALID_COLOR_FORMAT);
+        }
+    }
+}

--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
@@ -32,12 +32,15 @@ import com.ops.ops.modules.team.application.dto.response.TeamCreateResponse;
 import com.ops.ops.modules.team.domain.Team;
 import com.ops.ops.modules.team.domain.TeamSort;
 import com.ops.ops.modules.team.domain.dao.TeamRepository;
-import java.util.List;
-import java.util.Set;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -142,6 +145,11 @@ public class TeamCommandService {
         final TeamSort teamSort = teamSortConvenience.getValidateExistTeamSort();
 
         teamSort.updateSortType(request.mode());
+    }
+
+    public void updateAwardName(final Long teamId, final String awardName) {
+        final Team team = teamConvenience.getValidateExistTeam(teamId);
+        team.updateAwardName(awardName);
     }
 
     private void checkWebpConverted(File existingFile) {

--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
@@ -66,27 +66,34 @@ public class TeamCommandService {
 
     public void saveThumbnailImage(final Long teamId, final MultipartFile image) {
         teamConvenience.validateExistTeam(teamId);
-        fileRepository.findByTeamIdAndType(teamId, THUMBNAIL).ifPresent(existingFile -> {
-            checkWebpConverted(existingFile);
-            fileStorageUtil.deleteFile(existingFile.getId());
-        });
+        fileRepository
+                .findByTeamIdAndType(teamId, THUMBNAIL)
+                .ifPresent(
+                        existingFile -> {
+                            checkWebpConverted(existingFile);
+                            fileStorageUtil.deleteFile(existingFile.getId());
+                        });
         fileStorageUtil.storeFile(image, teamId, THUMBNAIL);
     }
 
     public void deleteThumbnailImage(Long teamId) {
         teamConvenience.validateExistTeam(teamId);
-        fileRepository.findByTeamIdAndType(teamId, THUMBNAIL).ifPresent(existingFile -> {
-            checkWebpConverted(existingFile);
-            fileStorageUtil.deleteFile(existingFile.getId());
-        });
+        fileRepository
+                .findByTeamIdAndType(teamId, THUMBNAIL)
+                .ifPresent(
+                        existingFile -> {
+                            checkWebpConverted(existingFile);
+                            fileStorageUtil.deleteFile(existingFile.getId());
+                        });
     }
 
     public void deletePreviewImages(Long teamId, List<Long> ids) {
         teamConvenience.validateExistTeam(teamId);
-        ids.forEach(fileId -> {
-            fileRepository.findById(fileId).ifPresent(this::checkWebpConverted);
-            fileStorageUtil.deleteFile(fileId);
-        });
+        ids.forEach(
+                fileId -> {
+                    fileRepository.findById(fileId).ifPresent(this::checkWebpConverted);
+                    fileStorageUtil.deleteFile(fileId);
+                });
     }
 
     public void savePreviewImages(Long teamId, List<MultipartFile> images) {
@@ -111,31 +118,41 @@ public class TeamCommandService {
         teamRepository.delete(team);
     }
 
-    public void updateTeamDetail(final Long teamId, final Member member, final TeamDetailUpdateRequest request) {
+    public void updateTeamDetail(
+            final Long teamId, final Member member, final TeamDetailUpdateRequest request) {
         final Team team = teamConvenience.getValidateExistTeam(teamId);
         final Contest newContest = contestConvenience.getValidateExistContest(request.contestId());
         checkTeamContestChange(team, newContest, member, request.teamName(), request.leaderName());
 
         updateLeaderIfChanged(team, request.leaderName());
 
-        team.updateDetail(request.leaderName(), request.teamName(), request.projectName(), request.overview(),
-                request.productionPath(), request.githubPath(), request.youTubePath(), request.contestId());
+        team.updateDetail(
+                request.leaderName(),
+                request.teamName(),
+                request.projectName(),
+                request.overview(),
+                request.productionPath(),
+                request.githubPath(),
+                request.youTubePath(),
+                request.contestId());
     }
 
     public TeamCreateResponse createTeam(TeamCreateRequest request) {
         final Contest contest = contestConvenience.getValidateExistContest(request.contestId());
         checkIsTeamCreatable(contest);
 
-        final Team team = teamRepository.save(Team.builder()
-                .leaderName(request.leaderName())
-                .teamName(request.teamName())
-                .projectName(request.projectName())
-                .overview(request.overview())
-                .productionPath(request.productionPath())
-                .githubPath(request.githubPath())
-                .youTubePath(request.youTubePath())
-                .contestId(contest.getId())
-                .build());
+        final Team team =
+                teamRepository.save(
+                        Team.builder()
+                                .leaderName(request.leaderName())
+                                .teamName(request.teamName())
+                                .projectName(request.projectName())
+                                .overview(request.overview())
+                                .productionPath(request.productionPath())
+                                .githubPath(request.githubPath())
+                                .youTubePath(request.youTubePath())
+                                .contestId(contest.getId())
+                                .build());
 
         teamMemberCommandService.assignFakeTeamMember(team, request.leaderName(), Set.of(ROLE_팀장));
 
@@ -184,8 +201,12 @@ public class TeamCommandService {
         }
     }
 
-    private void checkTeamContestChange(final Team team, final Contest newContest, final Member member,
-                                        final String newTeamName, final String newLeaderName) {
+    private void checkTeamContestChange(
+            final Team team,
+            final Contest newContest,
+            final Member member,
+            final String newTeamName,
+            final String newLeaderName) {
         final Contest oldContest = contestConvenience.getValidateExistContest(team.getContestId());
         if (oldContest.getIsCurrent()) {
             checkCurrentContest(team, newContest, newTeamName, newLeaderName);
@@ -194,8 +215,11 @@ public class TeamCommandService {
         }
     }
 
-    private void checkCurrentContest(final Team team, final Contest newContest, final String newTeamName,
-                                     final String newLeaderName) {
+    private void checkCurrentContest(
+            final Team team,
+            final Contest newContest,
+            final String newTeamName,
+            final String newLeaderName) {
         if (team.isContestChanged(newContest.getId())) {
             throw new ContestException(CANNOT_CHANGE_CONTEST_FOR_CURRENT);
         }

--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
@@ -10,6 +10,7 @@ import static com.ops.ops.modules.file.exception.FileExceptionType.EXCEED_PREVIE
 import static com.ops.ops.modules.file.exception.FileExceptionType.NOT_WEBP_CONVERTED;
 import static com.ops.ops.modules.member.domain.MemberRoleType.ROLE_관리자;
 import static com.ops.ops.modules.member.domain.MemberRoleType.ROLE_팀장;
+import static com.ops.ops.modules.team.exception.TeamExceptionType.INVALID_AWARD_PARAMETERS;
 
 import com.ops.ops.global.util.FileStorageUtil;
 import com.ops.ops.modules.contest.application.convenience.ContestConvenience;
@@ -32,6 +33,7 @@ import com.ops.ops.modules.team.application.dto.response.TeamCreateResponse;
 import com.ops.ops.modules.team.domain.Team;
 import com.ops.ops.modules.team.domain.TeamSort;
 import com.ops.ops.modules.team.domain.dao.TeamRepository;
+import com.ops.ops.modules.team.exception.TeamException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -147,9 +149,26 @@ public class TeamCommandService {
         teamSort.updateSortType(request.mode());
     }
 
-    public void updateAwardName(final Long teamId, final String awardName) {
+    public void updateAwardName(
+            final Long teamId, final String awardName, final String awardColor) {
+        validateAwardParameters(awardName, awardColor);
         final Team team = teamConvenience.getValidateExistTeam(teamId);
-        team.updateAwardName(awardName);
+        team.updateAward(awardName, awardColor);
+    }
+
+    private void validateAwardParameters(final String awardName, final String awardColor) {
+        if (awardName == null && awardColor == null) {
+            return;
+        }
+
+        if (awardName != null
+                && awardColor != null
+                && !awardName.trim().isEmpty()
+                && !awardColor.trim().isEmpty()) {
+            return;
+        }
+
+        throw new TeamException(INVALID_AWARD_PARAMETERS);
     }
 
     private void checkWebpConverted(File existingFile) {

--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
@@ -10,7 +10,6 @@ import static com.ops.ops.modules.file.exception.FileExceptionType.EXCEED_PREVIE
 import static com.ops.ops.modules.file.exception.FileExceptionType.NOT_WEBP_CONVERTED;
 import static com.ops.ops.modules.member.domain.MemberRoleType.ROLE_관리자;
 import static com.ops.ops.modules.member.domain.MemberRoleType.ROLE_팀장;
-import static com.ops.ops.modules.team.exception.TeamExceptionType.INVALID_AWARD_PARAMETERS;
 
 import com.ops.ops.global.util.FileStorageUtil;
 import com.ops.ops.modules.contest.application.convenience.ContestConvenience;
@@ -33,16 +32,12 @@ import com.ops.ops.modules.team.application.dto.response.TeamCreateResponse;
 import com.ops.ops.modules.team.domain.Team;
 import com.ops.ops.modules.team.domain.TeamSort;
 import com.ops.ops.modules.team.domain.dao.TeamRepository;
-import com.ops.ops.modules.team.exception.TeamException;
-
+import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
-import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -164,28 +159,6 @@ public class TeamCommandService {
         final TeamSort teamSort = teamSortConvenience.getValidateExistTeamSort();
 
         teamSort.updateSortType(request.mode());
-    }
-
-    public void updateAwardName(
-            final Long teamId, final String awardName, final String awardColor) {
-        validateAwardParameters(awardName, awardColor);
-        final Team team = teamConvenience.getValidateExistTeam(teamId);
-        team.updateAward(awardName, awardColor);
-    }
-
-    private void validateAwardParameters(final String awardName, final String awardColor) {
-        if (awardName == null && awardColor == null) {
-            return;
-        }
-
-        if (awardName != null
-                && awardColor != null
-                && !awardName.trim().isEmpty()
-                && !awardColor.trim().isEmpty()) {
-            return;
-        }
-
-        throw new TeamException(INVALID_AWARD_PARAMETERS);
     }
 
     private void checkWebpConverted(File existingFile) {

--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
@@ -121,11 +121,16 @@ public class TeamCommandService {
         final Contest contest = contestConvenience.getValidateExistContest(request.contestId());
         checkIsTeamCreatable(contest);
 
-        final Team team = teamRepository.save(
-                Team.builder().leaderName(request.leaderName()).teamName(request.teamName())
-                        .projectName(request.projectName()).overview(request.overview())
-                        .productionPath(request.productionPath()).githubPath(request.githubPath())
-                        .youTubePath(request.youTubePath()).contestId(contest.getId()).build());
+        final Team team = teamRepository.save(Team.builder()
+                .leaderName(request.leaderName())
+                .teamName(request.teamName())
+                .projectName(request.projectName())
+                .overview(request.overview())
+                .productionPath(request.productionPath())
+                .githubPath(request.githubPath())
+                .youTubePath(request.youTubePath())
+                .contestId(contest.getId())
+                .build());
 
         teamMemberCommandService.assignFakeTeamMember(team, request.leaderName(), Set.of(ROLE_팀장));
 
@@ -152,11 +157,8 @@ public class TeamCommandService {
         }
     }
 
-    private void checkTeamContestChange(final Team team,
-                                        final Contest newContest,
-                                        final Member member,
-                                        final String newTeamName,
-                                        final String newLeaderName) {
+    private void checkTeamContestChange(final Team team, final Contest newContest, final Member member,
+                                        final String newTeamName, final String newLeaderName) {
         final Contest oldContest = contestConvenience.getValidateExistContest(team.getContestId());
         if (oldContest.getIsCurrent()) {
             checkCurrentContest(team, newContest, newTeamName, newLeaderName);
@@ -165,9 +167,7 @@ public class TeamCommandService {
         }
     }
 
-    private void checkCurrentContest(final Team team,
-                                     final Contest newContest,
-                                     final String newTeamName,
+    private void checkCurrentContest(final Team team, final Contest newContest, final String newTeamName,
                                      final String newLeaderName) {
         if (team.isContestChanged(newContest.getId())) {
             throw new ContestException(CANNOT_CHANGE_CONTEST_FOR_CURRENT);

--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
@@ -61,34 +61,27 @@ public class TeamCommandService {
 
     public void saveThumbnailImage(final Long teamId, final MultipartFile image) {
         teamConvenience.validateExistTeam(teamId);
-        fileRepository
-                .findByTeamIdAndType(teamId, THUMBNAIL)
-                .ifPresent(
-                        existingFile -> {
-                            checkWebpConverted(existingFile);
-                            fileStorageUtil.deleteFile(existingFile.getId());
-                        });
+        fileRepository.findByTeamIdAndType(teamId, THUMBNAIL).ifPresent(existingFile -> {
+            checkWebpConverted(existingFile);
+            fileStorageUtil.deleteFile(existingFile.getId());
+        });
         fileStorageUtil.storeFile(image, teamId, THUMBNAIL);
     }
 
     public void deleteThumbnailImage(Long teamId) {
         teamConvenience.validateExistTeam(teamId);
-        fileRepository
-                .findByTeamIdAndType(teamId, THUMBNAIL)
-                .ifPresent(
-                        existingFile -> {
-                            checkWebpConverted(existingFile);
-                            fileStorageUtil.deleteFile(existingFile.getId());
-                        });
+        fileRepository.findByTeamIdAndType(teamId, THUMBNAIL).ifPresent(existingFile -> {
+            checkWebpConverted(existingFile);
+            fileStorageUtil.deleteFile(existingFile.getId());
+        });
     }
 
     public void deletePreviewImages(Long teamId, List<Long> ids) {
         teamConvenience.validateExistTeam(teamId);
-        ids.forEach(
-                fileId -> {
-                    fileRepository.findById(fileId).ifPresent(this::checkWebpConverted);
-                    fileStorageUtil.deleteFile(fileId);
-                });
+        ids.forEach(fileId -> {
+            fileRepository.findById(fileId).ifPresent(this::checkWebpConverted);
+            fileStorageUtil.deleteFile(fileId);
+        });
     }
 
     public void savePreviewImages(Long teamId, List<MultipartFile> images) {
@@ -113,41 +106,26 @@ public class TeamCommandService {
         teamRepository.delete(team);
     }
 
-    public void updateTeamDetail(
-            final Long teamId, final Member member, final TeamDetailUpdateRequest request) {
+    public void updateTeamDetail(final Long teamId, final Member member, final TeamDetailUpdateRequest request) {
         final Team team = teamConvenience.getValidateExistTeam(teamId);
         final Contest newContest = contestConvenience.getValidateExistContest(request.contestId());
         checkTeamContestChange(team, newContest, member, request.teamName(), request.leaderName());
 
         updateLeaderIfChanged(team, request.leaderName());
 
-        team.updateDetail(
-                request.leaderName(),
-                request.teamName(),
-                request.projectName(),
-                request.overview(),
-                request.productionPath(),
-                request.githubPath(),
-                request.youTubePath(),
-                request.contestId());
+        team.updateDetail(request.leaderName(), request.teamName(), request.projectName(), request.overview(),
+                request.productionPath(), request.githubPath(), request.youTubePath(), request.contestId());
     }
 
     public TeamCreateResponse createTeam(TeamCreateRequest request) {
         final Contest contest = contestConvenience.getValidateExistContest(request.contestId());
         checkIsTeamCreatable(contest);
 
-        final Team team =
-                teamRepository.save(
-                        Team.builder()
-                                .leaderName(request.leaderName())
-                                .teamName(request.teamName())
-                                .projectName(request.projectName())
-                                .overview(request.overview())
-                                .productionPath(request.productionPath())
-                                .githubPath(request.githubPath())
-                                .youTubePath(request.youTubePath())
-                                .contestId(contest.getId())
-                                .build());
+        final Team team = teamRepository.save(
+                Team.builder().leaderName(request.leaderName()).teamName(request.teamName())
+                        .projectName(request.projectName()).overview(request.overview())
+                        .productionPath(request.productionPath()).githubPath(request.githubPath())
+                        .youTubePath(request.youTubePath()).contestId(contest.getId()).build());
 
         teamMemberCommandService.assignFakeTeamMember(team, request.leaderName(), Set.of(ROLE_팀장));
 
@@ -174,12 +152,11 @@ public class TeamCommandService {
         }
     }
 
-    private void checkTeamContestChange(
-            final Team team,
-            final Contest newContest,
-            final Member member,
-            final String newTeamName,
-            final String newLeaderName) {
+    private void checkTeamContestChange(final Team team,
+                                        final Contest newContest,
+                                        final Member member,
+                                        final String newTeamName,
+                                        final String newLeaderName) {
         final Contest oldContest = contestConvenience.getValidateExistContest(team.getContestId());
         if (oldContest.getIsCurrent()) {
             checkCurrentContest(team, newContest, newTeamName, newLeaderName);
@@ -188,11 +165,10 @@ public class TeamCommandService {
         }
     }
 
-    private void checkCurrentContest(
-            final Team team,
-            final Contest newContest,
-            final String newTeamName,
-            final String newLeaderName) {
+    private void checkCurrentContest(final Team team,
+                                     final Contest newContest,
+                                     final String newTeamName,
+                                     final String newLeaderName) {
         if (team.isContestChanged(newContest.getId())) {
             throw new ContestException(CANNOT_CHANGE_CONTEST_FOR_CURRENT);
         }

--- a/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamAwardRequest.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamAwardRequest.java
@@ -1,0 +1,3 @@
+package com.ops.ops.modules.team.application.dto.request;
+
+public record TeamAwardRequest(String awardName) {}

--- a/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamAwardRequest.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamAwardRequest.java
@@ -1,3 +1,3 @@
 package com.ops.ops.modules.team.application.dto.request;
 
-public record TeamAwardRequest(String awardName) {}
+public record TeamAwardRequest(String awardName, String awardColor) {}

--- a/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamAwardRequest.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamAwardRequest.java
@@ -1,7 +1,22 @@
 package com.ops.ops.modules.team.application.dto.request;
 
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Pattern;
+
 public record TeamAwardRequest(
         String awardName,
+
+        @Pattern(regexp = "^#[A-Fa-f0-9]{6}$", message = "색상 정보가 올바르지 않습니다. (예: #FFFFFF)")
         String awardColor
 ) {
+
+    @AssertTrue(message = "수상명과 색상 정보가 올바르지 않습니다.")
+    public boolean isValidAwardParameters() {
+        if (awardName == null && awardColor == null) {
+            return true;
+        }
+
+        return awardName != null && awardColor != null &&
+                !awardName.trim().isEmpty() && !awardColor.trim().isEmpty();
+    }
 }

--- a/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamAwardRequest.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamAwardRequest.java
@@ -1,3 +1,7 @@
 package com.ops.ops.modules.team.application.dto.request;
 
-public record TeamAwardRequest(String awardName, String awardColor) {}
+public record TeamAwardRequest(
+        String awardName,
+        String awardColor
+) {
+}

--- a/src/main/java/com/ops/ops/modules/team/application/dto/response/TeamSummaryResponse.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/response/TeamSummaryResponse.java
@@ -6,14 +6,14 @@ public record TeamSummaryResponse(
         Long teamId,
         String teamName,
         String projectName,
-        boolean isLiked
-) {
+        boolean isLiked,
+        String awardName) {
     public static TeamSummaryResponse from(Team team, boolean isLiked) {
         return new TeamSummaryResponse(
                 team.getId(),
                 team.getTeamName(),
                 team.getProjectName(),
-                isLiked
-        );
+                isLiked,
+                team.getAwardName());
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/application/dto/response/TeamSummaryResponse.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/response/TeamSummaryResponse.java
@@ -7,13 +7,15 @@ public record TeamSummaryResponse(
         String teamName,
         String projectName,
         boolean isLiked,
-        String awardName) {
+        String awardName,
+        String awardColor) {
     public static TeamSummaryResponse from(Team team, boolean isLiked) {
         return new TeamSummaryResponse(
                 team.getId(),
                 team.getTeamName(),
                 team.getProjectName(),
                 isLiked,
-                team.getAwardName());
+                team.getAwardName(),
+                team.getAwardColor());
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/Team.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/Team.java
@@ -1,20 +1,24 @@
 package com.ops.ops.modules.team.domain;
 
 import com.ops.ops.global.base.BaseEntity;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
-import java.util.ArrayList;
-import java.util.List;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -41,14 +45,11 @@ public class Team extends BaseEntity {
     @Column(length = MAX_OVERVIEW_LENGTH)
     private String overview;
 
-    @Column
-    private String githubPath;
+    @Column private String githubPath;
 
-    @Column
-    private String productionPath;
+    @Column private String productionPath;
 
-    @Column
-    private String youTubePath;
+    @Column private String youTubePath;
 
     @Column(nullable = false)
     private Boolean isDeleted;
@@ -62,9 +63,18 @@ public class Team extends BaseEntity {
     @Column(nullable = false)
     private Long contestId;
 
+    @Column private String awardName;
+
     @Builder
-    public Team(final String leaderName, final String teamName, final String projectName, final String overview,
-                final String productionPath, final String githubPath, final String youTubePath, final Long contestId) {
+    public Team(
+            final String leaderName,
+            final String teamName,
+            final String projectName,
+            final String overview,
+            final String productionPath,
+            final String githubPath,
+            final String youTubePath,
+            final Long contestId) {
         this.leaderName = leaderName;
         this.teamName = teamName;
         this.projectName = projectName;
@@ -76,11 +86,18 @@ public class Team extends BaseEntity {
         this.isSubmitted = false;
         this.teamMembers = new ArrayList<>();
         this.contestId = contestId;
+        this.awardName = null;
     }
 
-    public void updateDetail(final String newLeaderName, final String newTeamName, final String newProjectName,
-                             final String newOverview, final String newProductionPath, final String newGithubPath,
-                             final String newYouTubePath, final Long newContestId) {
+    public void updateDetail(
+            final String newLeaderName,
+            final String newTeamName,
+            final String newProjectName,
+            final String newOverview,
+            final String newProductionPath,
+            final String newGithubPath,
+            final String newYouTubePath,
+            final Long newContestId) {
         this.leaderName = newLeaderName;
         this.teamName = newTeamName;
         this.projectName = newProjectName;
@@ -90,6 +107,10 @@ public class Team extends BaseEntity {
         this.youTubePath = newYouTubePath;
         this.isSubmitted = true;
         this.contestId = newContestId;
+    }
+
+    public void updateAwardName(final String awardName) {
+        this.awardName = awardName;
     }
 
     public boolean isContestChanged(Long newContestId) {

--- a/src/main/java/com/ops/ops/modules/team/domain/Team.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/Team.java
@@ -69,15 +69,8 @@ public class Team extends BaseEntity {
     private String awardColor;
 
     @Builder
-    public Team(
-            final String leaderName,
-            final String teamName,
-            final String projectName,
-            final String overview,
-            final String productionPath,
-            final String githubPath,
-            final String youTubePath,
-            final Long contestId) {
+    public Team(final String leaderName, final String teamName, final String projectName, final String overview,
+                final String productionPath, final String githubPath, final String youTubePath, final Long contestId) {
         this.leaderName = leaderName;
         this.teamName = teamName;
         this.projectName = projectName;
@@ -93,15 +86,9 @@ public class Team extends BaseEntity {
         this.awardColor = null;
     }
 
-    public void updateDetail(
-            final String newLeaderName,
-            final String newTeamName,
-            final String newProjectName,
-            final String newOverview,
-            final String newProductionPath,
-            final String newGithubPath,
-            final String newYouTubePath,
-            final Long newContestId) {
+    public void updateDetail(final String newLeaderName, final String newTeamName, final String newProjectName,
+                             final String newOverview, final String newProductionPath, final String newGithubPath,
+                             final String newYouTubePath, final Long newContestId) {
         this.leaderName = newLeaderName;
         this.teamName = newTeamName;
         this.projectName = newProjectName;

--- a/src/main/java/com/ops/ops/modules/team/domain/Team.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/Team.java
@@ -1,24 +1,20 @@
 package com.ops.ops.modules.team.domain;
 
 import com.ops.ops.global.base.BaseEntity;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
-
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
@@ -45,11 +41,14 @@ public class Team extends BaseEntity {
     @Column(length = MAX_OVERVIEW_LENGTH)
     private String overview;
 
-    @Column private String githubPath;
+    @Column
+    private String githubPath;
 
-    @Column private String productionPath;
+    @Column
+    private String productionPath;
 
-    @Column private String youTubePath;
+    @Column
+    private String youTubePath;
 
     @Column(nullable = false)
     private Boolean isDeleted;
@@ -63,9 +62,11 @@ public class Team extends BaseEntity {
     @Column(nullable = false)
     private Long contestId;
 
-    @Column private String awardName;
+    @Column
+    private String awardName;
 
-    @Column private String awardColor;
+    @Column
+    private String awardColor;
 
     @Builder
     public Team(

--- a/src/main/java/com/ops/ops/modules/team/domain/Team.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/Team.java
@@ -65,6 +65,8 @@ public class Team extends BaseEntity {
 
     @Column private String awardName;
 
+    @Column private String awardColor;
+
     @Builder
     public Team(
             final String leaderName,
@@ -87,6 +89,7 @@ public class Team extends BaseEntity {
         this.teamMembers = new ArrayList<>();
         this.contestId = contestId;
         this.awardName = null;
+        this.awardColor = null;
     }
 
     public void updateDetail(
@@ -109,8 +112,9 @@ public class Team extends BaseEntity {
         this.contestId = newContestId;
     }
 
-    public void updateAwardName(final String awardName) {
+    public void updateAward(final String awardName, final String awardColor) {
         this.awardName = awardName;
+        this.awardColor = awardColor;
     }
 
     public boolean isContestChanged(Long newContestId) {

--- a/src/main/java/com/ops/ops/modules/team/exception/TeamExceptionType.java
+++ b/src/main/java/com/ops/ops/modules/team/exception/TeamExceptionType.java
@@ -1,14 +1,14 @@
 package com.ops.ops.modules.team.exception;
 
 import com.ops.ops.global.base.BaseExceptionType;
-
 import org.springframework.http.HttpStatus;
 
 public enum TeamExceptionType implements BaseExceptionType {
     NOT_FOUND_TEAM(HttpStatus.NOT_FOUND, "팀을 찾을 수 없습니다."),
     NOT_TEAM_LEADER(HttpStatus.FORBIDDEN, "해당 팀의 팀장 권한이 없습니다."),
     EXIST_ONLY_ONE_ABOUT_TEAM_SORT(HttpStatus.NOT_FOUND, "팀 정렬 테이블의 id는 1번만 존재합니다."),
-    INVALID_AWARD_PARAMETERS(HttpStatus.BAD_REQUEST, "수상명과 색상 정보가 올바르지 않습니다.");
+    INVALID_AWARD_PARAMETERS(HttpStatus.BAD_REQUEST, "수상명과 색상 정보가 올바르지 않습니다."),
+    INVALID_COLOR_FORMAT(HttpStatus.BAD_REQUEST, "색상 정보가 올바르지 않습니다. (예: #FFFFFF)");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/com/ops/ops/modules/team/exception/TeamExceptionType.java
+++ b/src/main/java/com/ops/ops/modules/team/exception/TeamExceptionType.java
@@ -1,13 +1,14 @@
 package com.ops.ops.modules.team.exception;
 
 import com.ops.ops.global.base.BaseExceptionType;
+
 import org.springframework.http.HttpStatus;
 
 public enum TeamExceptionType implements BaseExceptionType {
     NOT_FOUND_TEAM(HttpStatus.NOT_FOUND, "팀을 찾을 수 없습니다."),
     NOT_TEAM_LEADER(HttpStatus.FORBIDDEN, "해당 팀의 팀장 권한이 없습니다."),
     EXIST_ONLY_ONE_ABOUT_TEAM_SORT(HttpStatus.NOT_FOUND, "팀 정렬 테이블의 id는 1번만 존재합니다."),
-    ;
+    INVALID_AWARD_PARAMETERS(HttpStatus.BAD_REQUEST, "수상명과 색상 정보가 올바르지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/com/ops/ops/modules/team/exception/TeamExceptionType.java
+++ b/src/main/java/com/ops/ops/modules/team/exception/TeamExceptionType.java
@@ -6,9 +6,7 @@ import org.springframework.http.HttpStatus;
 public enum TeamExceptionType implements BaseExceptionType {
     NOT_FOUND_TEAM(HttpStatus.NOT_FOUND, "팀을 찾을 수 없습니다."),
     NOT_TEAM_LEADER(HttpStatus.FORBIDDEN, "해당 팀의 팀장 권한이 없습니다."),
-    EXIST_ONLY_ONE_ABOUT_TEAM_SORT(HttpStatus.NOT_FOUND, "팀 정렬 테이블의 id는 1번만 존재합니다."),
-    INVALID_AWARD_PARAMETERS(HttpStatus.BAD_REQUEST, "수상명과 색상 정보가 올바르지 않습니다."),
-    INVALID_COLOR_FORMAT(HttpStatus.BAD_REQUEST, "색상 정보가 올바르지 않습니다. (예: #FFFFFF)");
+    EXIST_ONLY_ONE_ABOUT_TEAM_SORT(HttpStatus.NOT_FOUND, "팀 정렬 테이블의 id는 1번만 존재합니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #128 

## 📜 작업 내용

<img width="572" height="260" alt="Image" src="https://github.com/user-attachments/assets/2f318020-662c-4bd3-bab4-abd74b908df1" />


 관리자페이지에서 특정 대회, 특정 팀에게 수상을 등록할 수 있도록 구현하였습니다. 이를 위해 다음 2개의 API 작업이 필요하였습니다!

### 1. 수상 등록 API 구현
 관리자가 특정 팀에 수상명(상훈명)과 수상 색상을 등록할 수 있는 API가 필요합니다.
 이를 위해 `Team` 엔티티에 수상명이 등록될 필드 `awardName`과 'awardColor'를 추가하였습니다.

### 2. 대회 전체 팀 조회(Main) api 응답 수정
 메인페이지에서 수상 여부를 확인할 수 있어야 하므로 수상한 팀의 경우 수상명을, 수상하지 못한 팀의 경우 수상명과 색상이 null을 반환하도록 응답을 수정하였습니다.

## 💬 리뷰 요구사항
분명.. 우테코 포매터가 적용되었음을 여러번 확인하였는데 코드가 너무 많이 바뀌어서 좀 이상한 거 같네요 ㅠㅠㅠ
 

## ✨ 기타
화이팅-!
