### PR TITLE
Feature/#127 수동 정렬 api 개발

### DIFF
--- a/src/main/java/com/ops/ops/modules/contest/application/convenience/ContestConvenience.java
+++ b/src/main/java/com/ops/ops/modules/contest/application/convenience/ContestConvenience.java
@@ -46,4 +46,9 @@ public class ContestConvenience {
             throw new ContestException(NOT_VOTE_PERIOD_NOW);
         }
     }
+
+    @Transactional
+    public Contest findByIdForUpdate(final Long contestId) {
+        return contestRepository.findByIdForUpdate(contestId).orElseThrow(() -> new ContestException(NOT_FOUND_CONTEST));
+    }
 }

--- a/src/main/java/com/ops/ops/modules/contest/application/convenience/ContestConvenience.java
+++ b/src/main/java/com/ops/ops/modules/contest/application/convenience/ContestConvenience.java
@@ -4,6 +4,7 @@ import static com.ops.ops.modules.contest.exception.ContestExceptionType.CANNOT_
 import static com.ops.ops.modules.contest.exception.ContestExceptionType.CONTEST_NAME_ALREADY_EXIST;
 import static com.ops.ops.modules.contest.exception.ContestExceptionType.NOT_FOUND_CONTEST;
 import static com.ops.ops.modules.contest.exception.ContestExceptionType.NOT_VOTE_PERIOD_NOW;
+import static org.springframework.transaction.annotation.Propagation.MANDATORY;
 
 import com.ops.ops.modules.contest.domain.Contest;
 import com.ops.ops.modules.contest.domain.dao.ContestRepository;
@@ -47,7 +48,7 @@ public class ContestConvenience {
         }
     }
 
-    @Transactional
+    @Transactional(propagation = MANDATORY)
     public Contest findByIdForUpdate(final Long contestId) {
         return contestRepository.findByIdForUpdate(contestId).orElseThrow(() -> new ContestException(NOT_FOUND_CONTEST));
     }

--- a/src/main/java/com/ops/ops/modules/contest/domain/dao/ContestRepository.java
+++ b/src/main/java/com/ops/ops/modules/contest/domain/dao/ContestRepository.java
@@ -1,10 +1,12 @@
 package com.ops.ops.modules.contest.domain.dao;
 
-import java.util.Optional;
+import static jakarta.persistence.LockModeType.PESSIMISTIC_WRITE;
 
 import com.ops.ops.modules.contest.domain.Contest;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -12,4 +14,8 @@ public interface ContestRepository extends JpaRepository<Contest, Long> {
     boolean existsByContestName(String contestName);
 
     Optional<Contest> findByIsCurrentTrue();
+
+    @Lock(PESSIMISTIC_WRITE)
+    @Query("select c from Contest c where c.id = :contestId")
+    Optional<Contest> findByIdForUpdate(final Long contestId);
 }

--- a/src/main/java/com/ops/ops/modules/team/api/TeamController.java
+++ b/src/main/java/com/ops/ops/modules/team/api/TeamController.java
@@ -8,6 +8,7 @@ import com.ops.ops.modules.team.application.TeamQueryService;
 import com.ops.ops.modules.team.application.dto.request.PreviewDeleteRequest;
 import com.ops.ops.modules.team.application.dto.request.TeamCreateRequest;
 import com.ops.ops.modules.team.application.dto.request.TeamDetailUpdateRequest;
+import com.ops.ops.modules.team.application.dto.request.TeamSortCustomRequest;
 import com.ops.ops.modules.team.application.dto.request.TeamSortRequest;
 import com.ops.ops.modules.team.application.dto.response.TeamCreateResponse;
 import com.ops.ops.modules.team.application.dto.response.TeamDetailResponse;
@@ -182,5 +183,14 @@ public class TeamController {
     @Secured("ROLE_관리자")
     public ResponseEntity<TeamSortResponse> getTeamSort() {
         return ResponseEntity.ok(teamQueryService.getTeamSort());
+    }
+
+    @Operation(summary = "팀 수동 정렬", description = "관리자가 팀을 수동으로 정렬합니다. (CUSTOM)")
+    @ApiResponse(responseCode = "204", description = "팀 수동 정렬 성공")
+    @PatchMapping("/sort/custom")
+    @Secured("ROLE_관리자")
+    public ResponseEntity<Void> updateTeamSortCustom(@RequestBody @Valid final TeamSortCustomRequest request) {
+        teamCommandService.updateTeamSortCustom(request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
@@ -118,8 +118,10 @@ public class TeamCommandService {
     }
 
     public TeamCreateResponse createTeam(TeamCreateRequest request) {
-        final Contest contest = contestConvenience.getValidateExistContest(request.contestId());
+        final Contest contest = contestConvenience.findByIdForUpdate(request.contestId());
         checkIsTeamCreatable(contest);
+
+        final int nextOrder = teamRepository.findMaxItemOrderByContestId(contest.getId()) + 1;
 
         final Team team = teamRepository.save(Team.builder()
                 .leaderName(request.leaderName())
@@ -130,6 +132,7 @@ public class TeamCommandService {
                 .githubPath(request.githubPath())
                 .youTubePath(request.youTubePath())
                 .contestId(contest.getId())
+                .itemOrder(nextOrder)
                 .build());
 
         teamMemberCommandService.assignFakeTeamMember(team, request.leaderName(), Set.of(ROLE_팀장));

--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
@@ -10,6 +10,8 @@ import static com.ops.ops.modules.file.exception.FileExceptionType.EXCEED_PREVIE
 import static com.ops.ops.modules.file.exception.FileExceptionType.NOT_WEBP_CONVERTED;
 import static com.ops.ops.modules.member.domain.MemberRoleType.ROLE_관리자;
 import static com.ops.ops.modules.member.domain.MemberRoleType.ROLE_팀장;
+import static com.ops.ops.modules.team.domain.SortType.CUSTOM;
+import static com.ops.ops.modules.team.exception.TeamExceptionType.ONLY_CUSTOM_MODE_CAN_CHANGE;
 
 import com.ops.ops.global.util.FileStorageUtil;
 import com.ops.ops.modules.contest.application.convenience.ContestConvenience;
@@ -27,11 +29,13 @@ import com.ops.ops.modules.team.application.convenience.TeamMemberConvenience;
 import com.ops.ops.modules.team.application.convenience.TeamSortConvenience;
 import com.ops.ops.modules.team.application.dto.request.TeamCreateRequest;
 import com.ops.ops.modules.team.application.dto.request.TeamDetailUpdateRequest;
+import com.ops.ops.modules.team.application.dto.request.TeamSortCustomRequest;
 import com.ops.ops.modules.team.application.dto.request.TeamSortRequest;
 import com.ops.ops.modules.team.application.dto.response.TeamCreateResponse;
 import com.ops.ops.modules.team.domain.Team;
 import com.ops.ops.modules.team.domain.TeamSort;
 import com.ops.ops.modules.team.domain.dao.TeamRepository;
+import com.ops.ops.modules.team.exception.TeamException;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -147,6 +151,18 @@ public class TeamCommandService {
         teamSort.updateSortType(request.mode());
     }
 
+    public void updateTeamSortCustom(final TeamSortCustomRequest request) {
+        final TeamSort teamSort = teamSortConvenience.getValidateExistTeamSort();
+        checkCustomSort(teamSort);
+
+        final List<Team> teams = teamRepository.findAllByContestId(request.contestId());
+
+        for (TeamSortCustomRequest.TeamOrder order : request.teamOrders()) {
+            teams.stream().filter(team -> team.getId().equals(order.teamId())).findFirst()
+                    .ifPresent(team -> team.updateItemOrder(order.itemOrder()));
+        }
+    }
+
     private void checkWebpConverted(File existingFile) {
         if (!existingFile.isWebpConverted()) {
             throw new FileException(NOT_WEBP_CONVERTED);
@@ -204,6 +220,12 @@ public class TeamCommandService {
     private void checkIsTeamCreatable(final Contest contest) {
         if (!contest.isTeamCreatable()) {
             throw new ContestException(CANNOT_CREATE_TEAM_OF_CURRENT_CONTEST);
+        }
+    }
+
+    private void checkCustomSort(final TeamSort teamSort) {
+        if (!teamSort.getMode().equals(CUSTOM)) {
+            throw new TeamException(ONLY_CUSTOM_MODE_CAN_CHANGE);
         }
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
@@ -224,7 +224,7 @@ public class TeamCommandService {
     }
 
     private void checkCustomSort(final TeamSort teamSort) {
-        if (!teamSort.getMode().equals(CUSTOM)) {
+        if (teamSort.getMode() != CUSTOM) {
             throw new TeamException(ONLY_CUSTOM_MODE_CAN_CHANGE);
         }
     }

--- a/src/main/java/com/ops/ops/modules/team/application/convenience/TeamLikeConvenience.java
+++ b/src/main/java/com/ops/ops/modules/team/application/convenience/TeamLikeConvenience.java
@@ -36,9 +36,7 @@ public class TeamLikeConvenience {
                 Collections.shuffle(teams);
             }
         } else if (mode == CUSTOM) {
-            teams.sort(Comparator.comparing(Team::getContestId)
-                    .thenComparingInt(Team::getItemOrder)
-            );
+            teams.sort(Comparator.comparing(Team::getItemOrder));
         }
 
         final Map<Long, Boolean> likeMap =

--- a/src/main/java/com/ops/ops/modules/team/application/convenience/TeamLikeConvenience.java
+++ b/src/main/java/com/ops/ops/modules/team/application/convenience/TeamLikeConvenience.java
@@ -1,5 +1,6 @@
 package com.ops.ops.modules.team.application.convenience;
 
+import static com.ops.ops.modules.team.domain.SortType.CUSTOM;
 import static com.ops.ops.modules.team.domain.SortType.RANDOM;
 import static java.util.stream.Collectors.toMap;
 
@@ -10,6 +11,7 @@ import com.ops.ops.modules.team.domain.Team;
 import com.ops.ops.modules.team.domain.TeamLike;
 import com.ops.ops.modules.team.domain.dao.TeamLikeRepository;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -26,13 +28,17 @@ public class TeamLikeConvenience {
 
     public List<TeamSummaryResponse> getAllTeamSummaries(final List<Team> teams, final Member member,
                                                          final SortType mode) {
-        if (mode.equals(RANDOM)) {
+        if (mode == RANDOM) {
             if (member != null) {
                 Random seed = new Random(member.getId());
                 Collections.shuffle(teams, seed);
             } else {
                 Collections.shuffle(teams);
             }
+        } else if (mode == CUSTOM) {
+            teams.sort(Comparator.comparing(Team::getContestId)
+                    .thenComparingInt(Team::getItemOrder)
+            );
         }
 
         final Map<Long, Boolean> likeMap =

--- a/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamSortCustomRequest.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamSortCustomRequest.java
@@ -1,0 +1,20 @@
+package com.ops.ops.modules.team.application.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record TeamSortCustomRequest(
+        @NotNull
+        Long contestId,
+        @NotNull @Valid
+        List<TeamOrder> teamOrders
+) {
+    public record TeamOrder(
+            @NotNull
+            Long teamId,
+            @NotNull
+            Integer itemOrder
+    ) {
+    }
+}

--- a/src/main/java/com/ops/ops/modules/team/domain/SortType.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/SortType.java
@@ -2,5 +2,6 @@ package com.ops.ops.modules.team.domain;
 
 public enum SortType {
     ASC,
-    RANDOM
+    RANDOM,
+    CUSTOM
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/Team.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/Team.java
@@ -7,6 +7,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -21,6 +23,8 @@ import org.hibernate.annotations.SQLRestriction;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLRestriction("is_deleted = false")
 @SQLDelete(sql = "UPDATE team SET is_deleted = true where id = ?")
+@Table(name = "team", uniqueConstraints = {
+        @UniqueConstraint(name = "uq_team_contest_item_order", columnNames = {"contest_id", "item_order"})})
 public class Team extends BaseEntity {
 
     private static final int MAX_OVERVIEW_LENGTH = 3000;
@@ -62,9 +66,19 @@ public class Team extends BaseEntity {
     @Column(nullable = false)
     private Long contestId;
 
+    @Column
+    private String awardName;
+
+    @Column
+    private String awardColor;
+
+    @Column(nullable = false)
+    private Integer itemOrder;
+
     @Builder
     public Team(final String leaderName, final String teamName, final String projectName, final String overview,
-                final String productionPath, final String githubPath, final String youTubePath, final Long contestId) {
+                final String productionPath, final String githubPath, final String youTubePath, final Long contestId,
+                final Integer itemOrder) {
         this.leaderName = leaderName;
         this.teamName = teamName;
         this.projectName = projectName;
@@ -76,6 +90,9 @@ public class Team extends BaseEntity {
         this.isSubmitted = false;
         this.teamMembers = new ArrayList<>();
         this.contestId = contestId;
+        this.awardName = null;
+        this.awardColor = null;
+        this.itemOrder = itemOrder;
     }
 
     public void updateDetail(final String newLeaderName, final String newTeamName, final String newProjectName,

--- a/src/main/java/com/ops/ops/modules/team/domain/Team.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/Team.java
@@ -120,4 +120,8 @@ public class Team extends BaseEntity {
     public boolean isLeaderNameChanged(String newLeaderName) {
         return !this.getLeaderName().equals(newLeaderName);
     }
+
+    public void updateItemOrder(Integer newOrder) {
+        this.itemOrder = newOrder;
+    }
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/dao/TeamRepository.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/dao/TeamRepository.java
@@ -1,10 +1,10 @@
 package com.ops.ops.modules.team.domain.dao;
 
 import com.ops.ops.modules.team.domain.Team;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
 import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TeamRepository extends JpaRepository<Team, Long> {
@@ -13,4 +13,7 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
     List<Team> findByContestId(Long contestId);
 
     List<Team> findAllByContestId(Long contestId);
+
+    @Query("select coalesce(max(t.itemOrder), 0) from Team t where t.contestId = :contestId")
+    Integer findMaxItemOrderByContestId(final Long contestId);
 }

--- a/src/main/java/com/ops/ops/modules/team/exception/TeamExceptionType.java
+++ b/src/main/java/com/ops/ops/modules/team/exception/TeamExceptionType.java
@@ -7,6 +7,7 @@ public enum TeamExceptionType implements BaseExceptionType {
     NOT_FOUND_TEAM(HttpStatus.NOT_FOUND, "팀을 찾을 수 없습니다."),
     NOT_TEAM_LEADER(HttpStatus.FORBIDDEN, "해당 팀의 팀장 권한이 없습니다."),
     EXIST_ONLY_ONE_ABOUT_TEAM_SORT(HttpStatus.NOT_FOUND, "팀 정렬 테이블의 id는 1번만 존재합니다."),
+    ONLY_CUSTOM_MODE_CAN_CHANGE(HttpStatus.FORBIDDEN, "CUSTOM 모드에서만 정렬을 수정할 수 있습니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #127 

## 📜 작업 내용

- `SortType`에 `CUSTOM` 모드를 추가하고 관리자가 수동 정렬 가능하도록 수정했습니다.
  - 팀 추가 시 `itemOrder` 설정 -> 특정 대회의 `itemOrder`가 가장 큰 값 + 1 (대회가 없다면 1번 부터 시작)
  - `CUSTOM` 모드일 때, 순서 변경하면 `itemOrder` `update`
  - `itemOrder`는 `CUSTOM` 모드에서만 변경 가능하도록
  - `CUSTOM` 모드라면 전체 혹은 특정 팀 조회 시 `itemOrder`순으로 응답을 내려줌
  - `contest` 별 `itemOrder`는 `unique`하도록 제약

## 💬 리뷰 요구사항

- 순서를 쓰는 작업이라서 lock을 걸었습니다! flow 확인 부탁드려요!

## ✨ 기타
- 시간이 참 잘가네요,,,,,,,,,,,,