### PR TITLE
Bug/#131 정렬 시 unique 제약으로 인한 롤백 문제 해결

### DIFF
--- a/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamSortCustomRequest.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamSortCustomRequest.java
@@ -1,6 +1,7 @@
 package com.ops.ops.modules.team.application.dto.request;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
@@ -10,6 +11,16 @@ public record TeamSortCustomRequest(
         @NotNull @Valid
         List<TeamOrder> teamOrders
 ) {
+
+    @AssertTrue(message = "itemOrder 값이 중복되었습니다.")
+    public boolean isDistinctItemOrders() {
+        final long distinct = teamOrders.stream()
+                .map(TeamOrder::itemOrder)
+                .distinct()
+                .count();
+        return distinct == teamOrders.size();
+    }
+
     public record TeamOrder(
             @NotNull
             Long teamId,

--- a/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamSortCustomRequest.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamSortCustomRequest.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public record TeamSortCustomRequest(
         @NotNull
@@ -14,11 +15,10 @@ public record TeamSortCustomRequest(
 
     @AssertTrue(message = "itemOrder 값이 중복되었습니다.")
     public boolean isDistinctItemOrders() {
-        final long distinct = teamOrders.stream()
+        return teamOrders.stream()
                 .map(TeamOrder::itemOrder)
-                .distinct()
-                .count();
-        return distinct == teamOrders.size();
+                .collect(Collectors.toSet())
+                .size() == teamOrders.size();
     }
 
     public record TeamOrder(

--- a/src/main/java/com/ops/ops/modules/team/domain/Team.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/Team.java
@@ -7,8 +7,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -23,8 +21,6 @@ import org.hibernate.annotations.SQLRestriction;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLRestriction("is_deleted = false")
 @SQLDelete(sql = "UPDATE team SET is_deleted = true where id = ?")
-@Table(name = "team", uniqueConstraints = {
-        @UniqueConstraint(name = "uq_team_contest_item_order", columnNames = {"contest_id", "item_order"})})
 public class Team extends BaseEntity {
 
     private static final int MAX_OVERVIEW_LENGTH = 3000;


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #131

## 📜 작업 내용

- `contest` 별 `unique` 제약으로 인해 수동 정렬이 롤백되는 문제를 해결했습니다.
- 자세한 상황과 해결법은 이슈를 참고해 주세요!

## 💬 리뷰 요구사항

- `unique` 제약은 DB에서 직접 제거해서 현재 운영에는 문제가 없는 상황입니다!
- `itemOrder` 중복 값 확인은 저도 DTO에서 진행합니다 (태윤님 방식 참고했어요ㅎㅎ)
- 많은 해결법 중 `unique` 제약을 없애고 `itemOrder` 중복 확인으로 방향을 잡은 이유는, 삭제된 팀의 순서 때문에 `unique`로 하면 코드가 복잡해지기 때문입니다. (삭제된 팀의 `itemOrder`는 오지 않기 때문에 중복에 걸려버림)

## ✨ 기타

- 정렬은 항상 좀 복잡하죠ㅠ
