### PR TITLE
Feature/#133 팀 상세보기 지도교수 추가

### DIFF
--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
@@ -118,7 +118,8 @@ public class TeamCommandService {
         updateLeaderIfChanged(team, request.leaderName());
 
         team.updateDetail(request.leaderName(), request.teamName(), request.projectName(), request.overview(),
-                request.productionPath(), request.githubPath(), request.youTubePath(), request.contestId());
+                request.productionPath(), request.githubPath(), request.youTubePath(), request.contestId(),
+                request.professorName());
     }
 
     public TeamCreateResponse createTeam(TeamCreateRequest request) {

--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
@@ -137,6 +137,7 @@ public class TeamCommandService {
                 .youTubePath(request.youTubePath())
                 .contestId(contest.getId())
                 .itemOrder(nextOrder)
+                .professorName(request.professorName())
                 .build());
 
         teamMemberCommandService.assignFakeTeamMember(team, request.leaderName(), Set.of(ROLE_팀장));

--- a/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamCreateRequest.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamCreateRequest.java
@@ -18,6 +18,7 @@ public record TeamCreateRequest(
         @NotBlank(message = "깃헙주소는 필수입니다.")
         String githubPath,
         @NotBlank(message = "유튜브주소는 필수입니다.")
-        String youTubePath
+        String youTubePath,
+        String professorName
 ) {
 }

--- a/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamDetailUpdateRequest.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamDetailUpdateRequest.java
@@ -18,6 +18,7 @@ public record TeamDetailUpdateRequest(
         @NotBlank(message = "깃헙 주소는 필수입니다.")
         String githubPath,
         @NotBlank(message = "유튜브 주소는 필수입니다.")
-        String youTubePath
+        String youTubePath,
+        String professorName
 ) {
 }

--- a/src/main/java/com/ops/ops/modules/team/application/dto/response/TeamDetailResponse.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/response/TeamDetailResponse.java
@@ -18,7 +18,8 @@ public record TeamDetailResponse(
         String productionPath,
         String githubPath,
         String youTubePath,
-        boolean isLiked
+        boolean isLiked,
+        String professorName
 ) {
     public static TeamDetailResponse from(
             Contest contest,
@@ -42,7 +43,8 @@ public record TeamDetailResponse(
                 team.getProductionPath(),
                 team.getGithubPath(),
                 team.getYouTubePath(),
-                isLiked
+                isLiked,
+                team.getProfessorName()
         );
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/Team.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/Team.java
@@ -71,10 +71,13 @@ public class Team extends BaseEntity {
     @Column(nullable = false)
     private Integer itemOrder;
 
+    @Column
+    private String professorName;
+
     @Builder
     public Team(final String leaderName, final String teamName, final String projectName, final String overview,
                 final String productionPath, final String githubPath, final String youTubePath, final Long contestId,
-                final Integer itemOrder) {
+                final Integer itemOrder, final String professorName) {
         this.leaderName = leaderName;
         this.teamName = teamName;
         this.projectName = projectName;
@@ -89,11 +92,12 @@ public class Team extends BaseEntity {
         this.awardName = null;
         this.awardColor = null;
         this.itemOrder = itemOrder;
+        this.professorName = professorName;
     }
 
     public void updateDetail(final String newLeaderName, final String newTeamName, final String newProjectName,
                              final String newOverview, final String newProductionPath, final String newGithubPath,
-                             final String newYouTubePath, final Long newContestId) {
+                             final String newYouTubePath, final Long newContestId, final String newpPofessorName) {
         this.leaderName = newLeaderName;
         this.teamName = newTeamName;
         this.projectName = newProjectName;
@@ -103,6 +107,7 @@ public class Team extends BaseEntity {
         this.youTubePath = newYouTubePath;
         this.isSubmitted = true;
         this.contestId = newContestId;
+        this.professorName = newpPofessorName;
     }
 
     public void updateAward(final String awardName, final String awardColor) {

--- a/src/main/java/com/ops/ops/modules/team/domain/Team.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/Team.java
@@ -97,7 +97,7 @@ public class Team extends BaseEntity {
 
     public void updateDetail(final String newLeaderName, final String newTeamName, final String newProjectName,
                              final String newOverview, final String newProductionPath, final String newGithubPath,
-                             final String newYouTubePath, final Long newContestId, final String newpPofessorName) {
+                             final String newYouTubePath, final Long newContestId, final String newProfessorName) {
         this.leaderName = newLeaderName;
         this.teamName = newTeamName;
         this.projectName = newProjectName;
@@ -107,7 +107,7 @@ public class Team extends BaseEntity {
         this.youTubePath = newYouTubePath;
         this.isSubmitted = true;
         this.contestId = newContestId;
-        this.professorName = newpPofessorName;
+        this.professorName = newProfessorName;
     }
 
     public void updateAward(final String awardName, final String awardColor) {


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #133 

## 📜 작업 내용

> 팀 엔티티에 지도교수 칼럼을 추가하고 팀 상세보기 관련 api인 조회, 등록, 수정에 지도교수 필드를 추가하였습니다. 우선 지도교수를 수정 가능하게 해두었습니다.

## 💬 리뷰 요구사항

> 수정할 부분 있다면 말씀해주세요

## ✨ 기타
