### PR TITLE
Feature/#135 팀원 권한 추가

### DIFF
--- a/src/main/java/com/ops/ops/modules/member/domain/MemberRoleType.java
+++ b/src/main/java/com/ops/ops/modules/member/domain/MemberRoleType.java
@@ -7,6 +7,7 @@ public enum MemberRoleType {
     ROLE_회원(1),
     ROLE_팀장(2),
     ROLE_관리자(3),
+    ROLE_팀원(4),
     ;
 
     private final long id;

--- a/src/main/java/com/ops/ops/modules/team/api/TeamCommentController.java
+++ b/src/main/java/com/ops/ops/modules/team/api/TeamCommentController.java
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/teams/{teamId}/comments")
-@Secured({"ROLE_회원", "ROLE_팀장", "ROLE_관리자"})
+@Secured({"ROLE_회원", "ROLE_팀장", "ROLE_관리자", "ROLE_팀원"})
 public class TeamCommentController {
 
 	private final TeamCommentCommandService teamCommentCommandService;

--- a/src/main/java/com/ops/ops/modules/team/api/TeamController.java
+++ b/src/main/java/com/ops/ops/modules/team/api/TeamController.java
@@ -84,7 +84,7 @@ public class TeamController {
 
     @Operation(summary = "팀 썸네일 등록", description = "팀의 썸네일 이미지를 저장합니다.")
     @ApiResponse(responseCode = "201", description = "팀 썸네일 저장 완료")
-    @Secured({"ROLE_팀장", "ROLE_관리자"})
+    @Secured({"ROLE_팀장", "ROLE_관리자", "ROLE_팀원"})
     @PostMapping("/{teamId}/image/thumbnail")
     public ResponseEntity<Void> saveThumbnailImage(@PathVariable final Long teamId,
                                                    @RequestPart("image") final MultipartFile image) {
@@ -94,7 +94,7 @@ public class TeamController {
 
     @Operation(summary = "팀 썸네일 삭제", description = "팀의 썸네일 이미지를 삭제합니다.")
     @ApiResponse(responseCode = "204", description = "팀 썸네일 삭제 성공")
-    @Secured({"ROLE_팀장", "ROLE_관리자"})
+    @Secured({"ROLE_팀장", "ROLE_관리자", "ROLE_팀원"})
     @DeleteMapping("/{teamId}/image/thumbnail")
     public ResponseEntity<Void> deleteThumbnailImage(@PathVariable Long teamId) {
         teamCommandService.deleteThumbnailImage(teamId);
@@ -115,7 +115,7 @@ public class TeamController {
 
     @Operation(summary = "팀 프리뷰 등록", description = "팀의 프리뷰 이미지를 등록합니다.")
     @ApiResponse(responseCode = "201", description = "팀 프리뷰 등록 성공")
-    @Secured({"ROLE_팀장", "ROLE_관리자"})
+    @Secured({"ROLE_팀장", "ROLE_관리자", "ROLE_팀원"})
     @PostMapping("/{teamId}/image")
     public ResponseEntity<Void> savePreviewImage(@PathVariable Long teamId,
                                                  @RequestPart("images") final List<MultipartFile> images) {
@@ -125,7 +125,7 @@ public class TeamController {
 
     @Operation(summary = "팀 프리뷰 삭제", description = "팀의 프리뷰 이미지를 삭제합니다.")
     @ApiResponse(responseCode = "204", description = "팀 프리뷰 삭제 성공")
-    @Secured({"ROLE_팀장", "ROLE_관리자"})
+    @Secured({"ROLE_팀장", "ROLE_관리자", "ROLE_팀원"})
     @DeleteMapping("/{teamId}/image")
     public ResponseEntity<Void> deletePreviewImage(@PathVariable Long teamId,
                                                    @RequestBody @Valid PreviewDeleteRequest previewDeleteRequest) {
@@ -136,7 +136,7 @@ public class TeamController {
     @Operation(summary = "팀 상세보기 수정", description = "특정 팀의 상세보기를 수정합니다.")
     @ApiResponse(responseCode = "204", description = "팀 상세보기 수정 성공")
     @PatchMapping("/{teamId}")
-    @Secured({"ROLE_팀장", "ROLE_관리자"})
+    @Secured({"ROLE_팀장", "ROLE_관리자", "ROLE_팀원"})
     public ResponseEntity<Void> updateTeamDetail(
             @PathVariable final Long teamId,
             @Valid @RequestBody final TeamDetailUpdateRequest request,

--- a/src/main/java/com/ops/ops/modules/team/api/TeamLikeController.java
+++ b/src/main/java/com/ops/ops/modules/team/api/TeamLikeController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/teams")
-@Secured({"ROLE_회원", "ROLE_팀장", "ROLE_관리자"})
+@Secured({"ROLE_회원", "ROLE_팀장", "ROLE_관리자", "ROLE_팀원"})
 public class TeamLikeController {
 
     private final TeamLikeCommandService teamLikeService;


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #135

## 📜 작업 내용

- `ROLE_팀원`을 추가했습니다
- 팀장이 가지고 있는 권한에 팀원도 추가했습니다~

## 💬 리뷰 요구사항

- 관리자가 할 수 있는 멤버 삭제와 멤버 추가 관련
  - 현재 -> `멤버 추가` : fake member가 회원 권한을 가짐, `멤버 삭제` : 멤버 자체 삭제 입니다.
  - 멤버 추가 시 팀원 권한도 주고 삭제 시 팀원 권한만 뺄까 생각도 했지만, 일단 실제가 아닌 fake라서 음... 일단 진행하지는 않았습니다! 다른분들 생각은 어떠신가요??
- 팀 상세보기 작성 여부 조회 API는 팀장 단독 권한입니다! (팀원 X)
- 권한은 여러개 가질 수 있는데, 회원 권한이 있어 이미 접근할 수 있는 API에  `ROLE_팀원`을 추가한 이유는, 명시적으로 나타내기 위해 그냥 적었습니다~!

## ✨ 기타

- 이제는 팀원도 부산대 이메일로 가입하라고 해야하남..
