### PR TITLE
Feature/#137 좋아요 투표 횟수 계정당 2회 제한 기능 구현

### DIFF
--- a/src/main/java/com/ops/ops/modules/team/api/TeamLikeController.java
+++ b/src/main/java/com/ops/ops/modules/team/api/TeamLikeController.java
@@ -50,7 +50,7 @@ public class TeamLikeController {
             @ApiResponse(responseCode = "200", description = "좋아요 개수 조회 성공"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
     })
-    @GetMapping("/likes/count")
+    @GetMapping("/likes")
     public ResponseEntity<TeamLikeCountResponse> getUserLikeCount(@RequestParam Long contestId,
                                                                   @LoginMember Member member) {
         TeamLikeCountResponse response = new TeamLikeCountResponse(

--- a/src/main/java/com/ops/ops/modules/team/api/TeamLikeController.java
+++ b/src/main/java/com/ops/ops/modules/team/api/TeamLikeController.java
@@ -45,7 +45,7 @@ public class TeamLikeController {
         return ResponseEntity.ok(teamLikeService.toggleLike(member.getId(), teamId, request.isLiked()));
     }
 
-    @Operation(summary = "사용자의 좋아요 개수 상태 조회", description = "현재 사용자가 특정 공모전에서 좋아요를 누른 팀의 개수를 조회합니다.")
+    @Operation(summary = "사용자의 좋아요 개수 상태 조회", description = "현재 사용자가 특정 대회에서 좋아요를 누른 팀의 개수를 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "좋아요 개수 조회 성공"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")

--- a/src/main/java/com/ops/ops/modules/team/api/TeamLikeController.java
+++ b/src/main/java/com/ops/ops/modules/team/api/TeamLikeController.java
@@ -4,19 +4,23 @@ import com.ops.ops.global.security.annotation.LoginMember;
 import com.ops.ops.modules.member.domain.Member;
 import com.ops.ops.modules.team.application.TeamLikeCommandService;
 import com.ops.ops.modules.team.application.dto.request.TeamLikeToggleRequest;
+import com.ops.ops.modules.team.application.dto.response.TeamLikeCountResponse;
 import com.ops.ops.modules.team.application.dto.response.TeamLikeToggleResponse;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Team Like", description = "팀 좋아요 관련 API")
 @RestController
@@ -31,6 +35,7 @@ public class TeamLikeController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "좋아요 상태 변경 성공"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (중복, 제한 초과, 투표기간이 아님 등)"),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 팀 ID")
     })
     @PatchMapping("/{teamId}/like")
@@ -38,5 +43,18 @@ public class TeamLikeController {
                                                              @RequestBody @Valid TeamLikeToggleRequest request,
                                                              @LoginMember Member member) {
         return ResponseEntity.ok(teamLikeService.toggleLike(member.getId(), teamId, request.isLiked()));
+    }
+
+    @Operation(summary = "사용자의 좋아요 개수 상태 조회", description = "현재 사용자가 특정 공모전에서 좋아요를 누른 팀의 개수를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "좋아요 개수 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    })
+    @GetMapping("/likes/count")
+    public ResponseEntity<TeamLikeCountResponse> getUserLikeCount(@RequestParam Long contestId,
+                                                                  @LoginMember Member member) {
+        TeamLikeCountResponse response = new TeamLikeCountResponse(
+                teamLikeService.countCurrentMemberLikes(member.getId(), contestId));
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/api/TeamLikeController.java
+++ b/src/main/java/com/ops/ops/modules/team/api/TeamLikeController.java
@@ -4,7 +4,7 @@ import com.ops.ops.global.security.annotation.LoginMember;
 import com.ops.ops.modules.member.domain.Member;
 import com.ops.ops.modules.team.application.TeamLikeCommandService;
 import com.ops.ops.modules.team.application.dto.request.TeamLikeToggleRequest;
-import com.ops.ops.modules.team.application.dto.response.TeamLikeCountResponse;
+import com.ops.ops.modules.team.application.dto.response.MemberLikeCountResponse;
 import com.ops.ops.modules.team.application.dto.response.TeamLikeToggleResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -51,9 +51,8 @@ public class TeamLikeController {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
     })
     @GetMapping("/likes")
-    public ResponseEntity<TeamLikeCountResponse> getUserLikeCount(@RequestParam Long contestId,
-                                                                  @LoginMember Member member) {
-        TeamLikeCountResponse response = new TeamLikeCountResponse(
+    public ResponseEntity<MemberLikeCountResponse> getUserLikeCount(@RequestParam Long contestId, @LoginMember Member member) {
+        MemberLikeCountResponse response = new MemberLikeCountResponse(
                 teamLikeService.countCurrentMemberLikes(member.getId(), contestId));
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/ops/ops/modules/team/api/TeamLikeController.java
+++ b/src/main/java/com/ops/ops/modules/team/api/TeamLikeController.java
@@ -45,12 +45,12 @@ public class TeamLikeController {
         return ResponseEntity.ok(teamLikeService.toggleLike(member.getId(), teamId, request.isLiked()));
     }
 
-    @Operation(summary = "사용자의 좋아요 개수 상태 조회", description = "현재 사용자가 특정 공모전에서 좋아요를 누른 팀의 개수를 조회합니다.")
+    @Operation(summary = "사용자의 좋아요 개수 상태 조회", description = "현재 사용자가 특정 대회에서 좋아요를 누른 팀의 개수를 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "좋아요 개수 조회 성공"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
     })
-    @GetMapping("/likes/count")
+    @GetMapping("/likes")
     public ResponseEntity<TeamLikeCountResponse> getUserLikeCount(@RequestParam Long contestId,
                                                                   @LoginMember Member member) {
         TeamLikeCountResponse response = new TeamLikeCountResponse(

--- a/src/main/java/com/ops/ops/modules/team/application/TeamLikeCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamLikeCommandService.java
@@ -15,6 +15,7 @@ import com.ops.ops.modules.team.exception.TeamLikeExceptionType;
 import jakarta.transaction.Transactional;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -58,7 +59,7 @@ public class TeamLikeCommandService {
                                                       Boolean isLiked,
                                                       Long memberId,
                                                       Long contestId) {
-        if (teamLike.getIsLiked() == isLiked) { // 좋아요 상태 변화가 없는 경우
+        if (Objects.equals(teamLike.getIsLiked(), isLiked)) { // 좋아요 상태 변화가 없는 경우
             TeamLikeExceptionType exceptionType = isLiked ? ALREADY_LIKED : ALREADY_UNLIKED;
             throw new TeamLikeException(exceptionType);
         }

--- a/src/main/java/com/ops/ops/modules/team/application/TeamLikeCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamLikeCommandService.java
@@ -1,11 +1,17 @@
 package com.ops.ops.modules.team.application;
 
+import static com.ops.ops.modules.team.exception.TeamLikeExceptionType.ALREADY_LIKED;
+import static com.ops.ops.modules.team.exception.TeamLikeExceptionType.ALREADY_UNLIKED;
+import static com.ops.ops.modules.team.exception.TeamLikeExceptionType.LIKE_LIMIT_EXCEEDED;
+
 import com.ops.ops.modules.contest.application.convenience.ContestConvenience;
 import com.ops.ops.modules.team.application.convenience.TeamConvenience;
 import com.ops.ops.modules.team.application.dto.response.TeamLikeToggleResponse;
 import com.ops.ops.modules.team.domain.Team;
 import com.ops.ops.modules.team.domain.TeamLike;
 import com.ops.ops.modules.team.domain.dao.TeamLikeRepository;
+import com.ops.ops.modules.team.exception.TeamLikeException;
+import com.ops.ops.modules.team.exception.TeamLikeExceptionType;
 import jakarta.transaction.Transactional;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -17,6 +23,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Transactional
 public class TeamLikeCommandService {
+    private static final int MAX_LIKES_PER_CONTEST = 2;
 
     private final TeamLikeRepository teamLikeRepository;
     private final TeamConvenience teamConvenience;
@@ -28,21 +35,58 @@ public class TeamLikeCommandService {
                 ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime());
 
         Optional<TeamLike> teamLikeOptional = teamLikeRepository.findByMemberIdAndTeam(memberId, team);
-        if (teamLikeOptional.isEmpty()) {
-            saveTeamLike(memberId, team, isLiked);
-            String message = isLiked ? "좋아요가 처음 등록되었습니다." : "좋아요가 비활성화된 상태로 초기화되었습니다.";
-            return new TeamLikeToggleResponse(team.getId(), isLiked, message);
+
+        return teamLikeOptional.map(teamLike -> handleExistingLike(teamLike, isLiked, memberId, team.getContestId()))
+                .orElseGet(() -> handleFirstTimeLike(memberId, team, isLiked));
+    }
+
+    private TeamLikeToggleResponse handleFirstTimeLike(Long memberId, Team team, Boolean isLiked) {
+        long currentLikeCount = countCurrentMemberLikes(memberId, team.getContestId());
+
+        if (isLiked) {
+            validateLikeLimit(currentLikeCount);
+            currentLikeCount++;
         }
 
-        TeamLike teamLike = teamLikeOptional.get();
-        if (teamLike.getIsLiked() == isLiked) {
-            String message = isLiked ? "이미 좋아요한 팀입니다." : "이미 좋아요를 취소한 팀입니다.";
-            return new TeamLikeToggleResponse(team.getId(), teamLike.getIsLiked(), message);
+        saveTeamLike(memberId, team, isLiked);
+
+        String message = isLiked ? "좋아요가 처음 등록되었습니다." : "좋아요가 비활성화된 상태로 초기화되었습니다.";
+        return new TeamLikeToggleResponse(team.getId(), isLiked, message, currentLikeCount);
+    }
+
+    private TeamLikeToggleResponse handleExistingLike(TeamLike teamLike,
+                                                      Boolean isLiked,
+                                                      Long memberId,
+                                                      Long contestId) {
+        if (teamLike.getIsLiked() == isLiked) { // 좋아요 상태 변화가 없는 경우
+            TeamLikeExceptionType exceptionType = isLiked ? ALREADY_LIKED : ALREADY_UNLIKED;
+            throw new TeamLikeException(exceptionType);
+        }
+
+        long currentLikeCount = countCurrentMemberLikes(memberId, contestId);
+
+        // 좋아요 상태 변경 처리
+        if (isLiked) { // 좋아요 등록
+            validateLikeLimit(currentLikeCount);
+            currentLikeCount++;
+        } else { // 좋아요 취소
+            currentLikeCount--;
         }
 
         teamLike.setLiked(isLiked);
+
         String message = isLiked ? "좋아요가 등록되었습니다." : "좋아요가 취소되었습니다.";
-        return new TeamLikeToggleResponse(team.getId(), isLiked, message);
+        return new TeamLikeToggleResponse(teamLike.getTeam().getId(), isLiked, message, currentLikeCount);
+    }
+
+    public long countCurrentMemberLikes(Long memberId, Long contestId) {
+        return teamLikeRepository.countMemberLikesInContest(memberId, contestId);
+    }
+
+    private void validateLikeLimit(long currentLikeCount) {
+        if (currentLikeCount >= MAX_LIKES_PER_CONTEST) {
+            throw new TeamLikeException(LIKE_LIMIT_EXCEEDED);
+        }
     }
 
     private void saveTeamLike(Long memberId, Team team, Boolean isLiked) {

--- a/src/main/java/com/ops/ops/modules/team/application/TeamLikeCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamLikeCommandService.java
@@ -55,10 +55,7 @@ public class TeamLikeCommandService {
         return new TeamLikeToggleResponse(team.getId(), isLiked, message, currentLikeCount);
     }
 
-    private TeamLikeToggleResponse handleExistingLike(TeamLike teamLike,
-                                                      Boolean isLiked,
-                                                      Long memberId,
-                                                      Long contestId) {
+    private TeamLikeToggleResponse handleExistingLike(TeamLike teamLike, Boolean isLiked, Long memberId, Long contestId) {
         if (Objects.equals(teamLike.getIsLiked(), isLiked)) { // 좋아요 상태 변화가 없는 경우
             TeamLikeExceptionType exceptionType = isLiked ? ALREADY_LIKED : ALREADY_UNLIKED;
             throw new TeamLikeException(exceptionType);

--- a/src/main/java/com/ops/ops/modules/team/application/TeamLikeCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamLikeCommandService.java
@@ -80,6 +80,7 @@ public class TeamLikeCommandService {
     }
 
     public long countCurrentMemberLikes(Long memberId, Long contestId) {
+        contestConvenience.getValidateExistContest(contestId);
         return teamLikeRepository.countMemberLikesInContest(memberId, contestId);
     }
 

--- a/src/main/java/com/ops/ops/modules/team/application/TeamLikeCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamLikeCommandService.java
@@ -80,6 +80,8 @@ public class TeamLikeCommandService {
     }
 
     public long countCurrentMemberLikes(Long memberId, Long contestId) {
+        contestConvenience.checkVotePeriodNow(contestId,
+                ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime());
         return teamLikeRepository.countMemberLikesInContest(memberId, contestId);
     }
 

--- a/src/main/java/com/ops/ops/modules/team/application/dto/response/MemberLikeCountResponse.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/response/MemberLikeCountResponse.java
@@ -1,0 +1,6 @@
+package com.ops.ops.modules.team.application.dto.response;
+
+public record MemberLikeCountResponse(
+        Long currentMemberLikeCount
+) {
+}

--- a/src/main/java/com/ops/ops/modules/team/application/dto/response/TeamLikeCountResponse.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/response/TeamLikeCountResponse.java
@@ -1,6 +1,0 @@
-package com.ops.ops.modules.team.application.dto.response;
-
-public record TeamLikeCountResponse(
-        Long currentLikeCount
-) {
-}

--- a/src/main/java/com/ops/ops/modules/team/application/dto/response/TeamLikeCountResponse.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/response/TeamLikeCountResponse.java
@@ -1,0 +1,6 @@
+package com.ops.ops.modules.team.application.dto.response;
+
+public record TeamLikeCountResponse(
+        Long currentLikeCount
+) {
+}

--- a/src/main/java/com/ops/ops/modules/team/application/dto/response/TeamLikeToggleResponse.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/response/TeamLikeToggleResponse.java
@@ -1,8 +1,9 @@
 package com.ops.ops.modules.team.application.dto.response;
 
 public record TeamLikeToggleResponse(
-	Long teamId,
-	Boolean isLiked,
-	String message
+        Long teamId,
+        Boolean isLiked,
+        String message,
+        Long currentLikeCount
 ) {
 }

--- a/src/main/java/com/ops/ops/modules/team/application/dto/response/TeamLikeToggleResponse.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/response/TeamLikeToggleResponse.java
@@ -4,6 +4,6 @@ public record TeamLikeToggleResponse(
         Long teamId,
         Boolean isLiked,
         String message,
-        Long currentLikeCount
+        Long currentMemberLikeCount
 ) {
 }

--- a/src/main/java/com/ops/ops/modules/team/domain/dao/TeamLikeRepository.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/dao/TeamLikeRepository.java
@@ -23,4 +23,7 @@ public interface TeamLikeRepository extends JpaRepository<TeamLike, Long> {
     List<TeamLike> findAllByMemberIdAndTeamIn(Long id, List<Team> teams);
 
     void deleteAllByTeamId(Long teamId);
+
+    @Query("SELECT COUNT(tl) FROM TeamLike tl JOIN tl.team t WHERE tl.memberId = :memberId AND tl.isLiked = true AND t.contestId = :contestId")
+    long countMemberLikesInContest(Long memberId, Long contestId);
 }

--- a/src/main/java/com/ops/ops/modules/team/exception/TeamLikeException.java
+++ b/src/main/java/com/ops/ops/modules/team/exception/TeamLikeException.java
@@ -1,0 +1,18 @@
+package com.ops.ops.modules.team.exception;
+
+import com.ops.ops.global.base.BaseException;
+import com.ops.ops.global.base.BaseExceptionType;
+
+public class TeamLikeException extends BaseException {
+    private final TeamLikeExceptionType exceptionType;
+
+    public TeamLikeException(final TeamLikeExceptionType exceptionType) {
+        super(exceptionType.errorMessage());
+        this.exceptionType = exceptionType;
+    }
+
+    @Override
+    public BaseExceptionType exceptionType() {
+        return exceptionType;
+    }
+}

--- a/src/main/java/com/ops/ops/modules/team/exception/TeamLikeExceptionType.java
+++ b/src/main/java/com/ops/ops/modules/team/exception/TeamLikeExceptionType.java
@@ -1,0 +1,28 @@
+package com.ops.ops.modules.team.exception;
+
+import com.ops.ops.global.base.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum TeamLikeExceptionType implements BaseExceptionType {
+    LIKE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "대회당 최대 2개 팀만 좋아요할 수 있습니다."),
+    ALREADY_LIKED(HttpStatus.BAD_REQUEST, "이미 좋아요한 팀입니다."),
+    ALREADY_UNLIKED(HttpStatus.BAD_REQUEST, "이미 좋아요를 취소한 팀입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+
+    TeamLikeExceptionType(final HttpStatus httpStatus, final String errorMessage) {
+        this.httpStatus = httpStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String errorMessage() {
+        return errorMessage;
+    }
+}


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #137 

## 📜 작업 내용

 팀 좋아요 기능에 대회별 투표 제한 및 시나리오별 검증 로직을 구현하였습니다. 
 각 사용자는 대회당 최대 2개 팀에만 좋아요할 수 있으며, 모든 예외 상황에 대한 적절한 예외 처리를 해주었습니다!
 
### 1. 대회별 좋아요 제한 검증
 중간 테이블을 만들지, 필드값을 추가할지 고민이 많이 되었는데 이미 `TeamLike` 테이블의 칼럼이 좋아요 정보를 담고 있기에 JOIN 쿼리를 통해 중복 데이터 없이 효율적으로 집계하는 방법으로 `TeamLikeRepository.countMemberLikesInContest()` 메서드 를 추가하였습니다!

### 2. 시나리오별 응답 처리
 API 명세서에도 작성하였습니다!
<img width="663" height="190" alt="스크린샷 2025-09-27 오후 6 16 13" src="https://github.com/user-attachments/assets/8178c8fb-6574-4036-9220-40e61489dc1d" />
<img width="695" height="248" alt="스크린샷 2025-09-27 오후 6 16 23" src="https://github.com/user-attachments/assets/1cf74050-15d4-4b1c-9624-0ec351fe7e4f" />

### 3. 응답 DTO에 현재 사용자가 대회에서 좋아요 투표를 한 수를 알 수 있도록 필드값을 추가하였습니다.

### 4. 대회에서 사용자의 좋아요 투표 개수 조회 API 추가 구현
 프론트분들께서 요청해주셔서 조회 API를 추가적으로 구현하였습니다!

## 💬 리뷰 요구사항

 시나리오별 응답 처리 부분이 복잡하여 코드 단에서 최대한 가독성을 중요시하여 구현해봤는데 여전히 가독성이 좋지 않은 거 같네요 ㅠ.ㅠ
-> 시나리오별 분기 처리에 대해 개선할 방법이 있다면 말씀해주세요!

## ✨ 기타
 모든 시나리오 및 예외사항을 포스트맨으로 테스트 완료하였습니다! 
