### PR TITLE
Feature/#139 팀 상세보기수정 관리자 null 가능 기능추가

### DIFF
--- a/src/main/java/com/ops/ops/modules/team/api/TeamController.java
+++ b/src/main/java/com/ops/ops/modules/team/api/TeamController.java
@@ -137,10 +137,9 @@ public class TeamController {
     @ApiResponse(responseCode = "204", description = "팀 상세보기 수정 성공")
     @PatchMapping("/{teamId}")
     @Secured({"ROLE_팀장", "ROLE_관리자", "ROLE_팀원"})
-    public ResponseEntity<Void> updateTeamDetail(
-            @PathVariable final Long teamId,
-            @Valid @RequestBody final TeamDetailUpdateRequest request,
-            @LoginMember final Member member
+    public ResponseEntity<Void> updateTeamDetail(@PathVariable final Long teamId,
+                                                 @Valid @RequestBody final TeamDetailUpdateRequest request,
+                                                 @LoginMember final Member member
     ) {
         teamCommandService.updateTeamDetail(teamId, member, request);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
@@ -9,8 +9,10 @@ import static com.ops.ops.modules.file.domain.FileImageType.THUMBNAIL;
 import static com.ops.ops.modules.file.exception.FileExceptionType.EXCEED_PREVIEW_LIMIT;
 import static com.ops.ops.modules.file.exception.FileExceptionType.NOT_WEBP_CONVERTED;
 import static com.ops.ops.modules.member.domain.MemberRoleType.ROLE_관리자;
+import static com.ops.ops.modules.member.domain.MemberRoleType.ROLE_팀원;
 import static com.ops.ops.modules.member.domain.MemberRoleType.ROLE_팀장;
 import static com.ops.ops.modules.team.domain.SortType.CUSTOM;
+import static com.ops.ops.modules.team.exception.TeamExceptionType.MUST_FILL_FIELD;
 import static com.ops.ops.modules.team.exception.TeamExceptionType.ONLY_CUSTOM_MODE_CAN_CHANGE;
 
 import com.ops.ops.global.util.FileStorageUtil;
@@ -22,6 +24,7 @@ import com.ops.ops.modules.file.domain.dao.FileRepository;
 import com.ops.ops.modules.file.exception.FileException;
 import com.ops.ops.modules.member.application.convenience.MemberConvenience;
 import com.ops.ops.modules.member.domain.Member;
+import com.ops.ops.modules.member.domain.MemberRoleType;
 import com.ops.ops.modules.team.application.convenience.TeamCommentConvenience;
 import com.ops.ops.modules.team.application.convenience.TeamConvenience;
 import com.ops.ops.modules.team.application.convenience.TeamLikeConvenience;
@@ -38,6 +41,7 @@ import com.ops.ops.modules.team.domain.dao.TeamRepository;
 import com.ops.ops.modules.team.exception.TeamException;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -113,6 +117,10 @@ public class TeamCommandService {
     public void updateTeamDetail(final Long teamId, final Member member, final TeamDetailUpdateRequest request) {
         final Team team = teamConvenience.getValidateExistTeam(teamId);
         final Contest newContest = contestConvenience.getValidateExistContest(request.contestId());
+        final Set<MemberRoleType> roles = member.getRoles();
+
+        checkRoleBaseValidation(request, roles);
+
         checkTeamContestChange(team, newContest, member, request.teamName(), request.leaderName());
 
         updateLeaderIfChanged(team, request.leaderName());
@@ -120,6 +128,20 @@ public class TeamCommandService {
         team.updateDetail(request.leaderName(), request.teamName(), request.projectName(), request.overview(),
                 request.productionPath(), request.githubPath(), request.youTubePath(), request.contestId(),
                 request.professorName());
+    }
+
+    private void checkRoleBaseValidation(TeamDetailUpdateRequest request, Set<MemberRoleType> roles) {
+        if (roles.contains(ROLE_팀장) || roles.contains(ROLE_팀원)) {
+            Stream.of(request.teamName(), request.projectName(), request.leaderName(), request.overview(),
+                    request.githubPath(), request.youTubePath()
+            ).forEach(this::checkNullAndEmpty);
+        }
+    }
+
+    private void checkNullAndEmpty(String s) {
+        if (s == null || s.trim().isEmpty()) {
+            throw new TeamException(MUST_FILL_FIELD);
+        }
     }
 
     public TeamCreateResponse createTeam(TeamCreateRequest request) {

--- a/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamCommandService.java
@@ -11,6 +11,7 @@ import static com.ops.ops.modules.file.exception.FileExceptionType.NOT_WEBP_CONV
 import static com.ops.ops.modules.member.domain.MemberRoleType.ROLE_관리자;
 import static com.ops.ops.modules.member.domain.MemberRoleType.ROLE_팀원;
 import static com.ops.ops.modules.member.domain.MemberRoleType.ROLE_팀장;
+import static com.ops.ops.modules.member.domain.MemberRoleType.ROLE_회원;
 import static com.ops.ops.modules.team.domain.SortType.CUSTOM;
 import static com.ops.ops.modules.team.exception.TeamExceptionType.MUST_FILL_FIELD;
 import static com.ops.ops.modules.team.exception.TeamExceptionType.ONLY_CUSTOM_MODE_CAN_CHANGE;
@@ -131,7 +132,7 @@ public class TeamCommandService {
     }
 
     private void checkRoleBaseValidation(TeamDetailUpdateRequest request, Set<MemberRoleType> roles) {
-        if (roles.contains(ROLE_팀장) || roles.contains(ROLE_팀원)) {
+        if (roles.contains(ROLE_팀장) || roles.contains(ROLE_팀원) || roles.contains(ROLE_회원)) {
             Stream.of(request.teamName(), request.projectName(), request.leaderName(), request.overview(),
                     request.githubPath(), request.youTubePath()
             ).forEach(this::checkNullAndEmpty);

--- a/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamDetailUpdateRequest.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/request/TeamDetailUpdateRequest.java
@@ -1,23 +1,16 @@
 package com.ops.ops.modules.team.application.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record TeamDetailUpdateRequest(
         @NotNull(message = "대회 ID는 필수입니다.")
         Long contestId,
-        @NotBlank(message = "팀명은 필수입니다.")
         String teamName,
-        @NotBlank(message = "프로젝트명은 필수입니다.")
         String projectName,
-        @NotBlank(message = "팀장 이름은 필수입니다.")
         String leaderName,
-        @NotBlank(message = "프로젝트 설명은 필수입니다.")
         String overview,
         String productionPath,
-        @NotBlank(message = "깃헙 주소는 필수입니다.")
         String githubPath,
-        @NotBlank(message = "유튜브 주소는 필수입니다.")
         String youTubePath,
         String professorName
 ) {

--- a/src/main/java/com/ops/ops/modules/team/domain/Team.java
+++ b/src/main/java/com/ops/ops/modules/team/domain/Team.java
@@ -29,13 +29,10 @@ public class Team extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
     private String leaderName;
 
-    @Column(nullable = false)
     private String teamName;
 
-    @Column(nullable = false)
     private String projectName;
 
     @Column(length = MAX_OVERVIEW_LENGTH)

--- a/src/main/java/com/ops/ops/modules/team/exception/TeamExceptionType.java
+++ b/src/main/java/com/ops/ops/modules/team/exception/TeamExceptionType.java
@@ -8,6 +8,7 @@ public enum TeamExceptionType implements BaseExceptionType {
     NOT_TEAM_LEADER(HttpStatus.FORBIDDEN, "해당 팀의 팀장 권한이 없습니다."),
     EXIST_ONLY_ONE_ABOUT_TEAM_SORT(HttpStatus.NOT_FOUND, "팀 정렬 테이블의 id는 1번만 존재합니다."),
     ONLY_CUSTOM_MODE_CAN_CHANGE(HttpStatus.FORBIDDEN, "CUSTOM 모드에서만 정렬을 수정할 수 있습니다."),
+    MUST_FILL_FIELD(HttpStatus.BAD_REQUEST, "필드를 작성해야 합니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #139 

## 📜 작업 내용

> 관리자는 필드를 모두 채우지 않더라도 제출 가능하도록 수정
> 팀장, 팀원 권한인 경우에만 필드를 모두 채웠는지 확인하도록 구현했습니다

## 💬 리뷰 요구사항

> 검증에 부족한 점이 있는지 봐주시면 감사하겠습니다~


