### PR TITLE
Refactor/#141-좋아요 관련 API 응답값 수정

### DIFF
--- a/src/main/java/com/ops/ops/modules/team/api/TeamLikeController.java
+++ b/src/main/java/com/ops/ops/modules/team/api/TeamLikeController.java
@@ -42,7 +42,8 @@ public class TeamLikeController {
     public ResponseEntity<TeamLikeToggleResponse> toggleLike(@PathVariable Long teamId,
                                                              @RequestBody @Valid TeamLikeToggleRequest request,
                                                              @LoginMember Member member) {
-        return ResponseEntity.ok(teamLikeService.toggleLike(member.getId(), teamId, request.isLiked()));
+        TeamLikeToggleResponse response = teamLikeService.toggleLike(member.getId(), teamId, request.isLiked());
+        return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "사용자의 좋아요 개수 상태 조회", description = "현재 사용자가 특정 대회에서 좋아요를 누른 팀의 개수를 조회합니다.")
@@ -52,8 +53,7 @@ public class TeamLikeController {
     })
     @GetMapping("/likes")
     public ResponseEntity<MemberLikeCountResponse> getUserLikeCount(@RequestParam Long contestId, @LoginMember Member member) {
-        MemberLikeCountResponse response = new MemberLikeCountResponse(
-                teamLikeService.countCurrentMemberLikes(member.getId(), contestId));
+        MemberLikeCountResponse response = teamLikeService.getMemberLikeCount(member.getId(), contestId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/application/TeamLikeCommandService.java
+++ b/src/main/java/com/ops/ops/modules/team/application/TeamLikeCommandService.java
@@ -6,6 +6,7 @@ import static com.ops.ops.modules.team.exception.TeamLikeExceptionType.LIKE_LIMI
 
 import com.ops.ops.modules.contest.application.convenience.ContestConvenience;
 import com.ops.ops.modules.team.application.convenience.TeamConvenience;
+import com.ops.ops.modules.team.application.dto.response.MemberLikeCountResponse;
 import com.ops.ops.modules.team.application.dto.response.TeamLikeToggleResponse;
 import com.ops.ops.modules.team.domain.Team;
 import com.ops.ops.modules.team.domain.TeamLike;
@@ -24,7 +25,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Transactional
 public class TeamLikeCommandService {
-    private static final int MAX_LIKES_PER_CONTEST = 2;
+    private static final long MAX_LIKES_PER_CONTEST = 2;
 
     private final TeamLikeRepository teamLikeRepository;
     private final TeamConvenience teamConvenience;
@@ -52,7 +53,7 @@ public class TeamLikeCommandService {
         saveTeamLike(memberId, team, isLiked);
 
         String message = isLiked ? "좋아요가 처음 등록되었습니다." : "좋아요가 비활성화된 상태로 초기화되었습니다.";
-        return new TeamLikeToggleResponse(team.getId(), isLiked, message, currentLikeCount);
+        return TeamLikeToggleResponse.of(team.getId(), isLiked, message, currentLikeCount, MAX_LIKES_PER_CONTEST);
     }
 
     private TeamLikeToggleResponse handleExistingLike(TeamLike teamLike, Boolean isLiked, Long memberId, Long contestId) {
@@ -74,11 +75,10 @@ public class TeamLikeCommandService {
         teamLike.setLiked(isLiked);
 
         String message = isLiked ? "좋아요가 등록되었습니다." : "좋아요가 취소되었습니다.";
-        return new TeamLikeToggleResponse(teamLike.getTeam().getId(), isLiked, message, currentLikeCount);
+        return TeamLikeToggleResponse.of(teamLike.getTeam().getId(), isLiked, message, currentLikeCount, MAX_LIKES_PER_CONTEST);
     }
 
-    public long countCurrentMemberLikes(Long memberId, Long contestId) {
-        contestConvenience.getValidateExistContest(contestId);
+    private long countCurrentMemberLikes(Long memberId, Long contestId) {
         return teamLikeRepository.countMemberLikesInContest(memberId, contestId);
     }
 
@@ -94,5 +94,12 @@ public class TeamLikeCommandService {
                 .team(team)
                 .isLiked(isLiked)
                 .build());
+    }
+
+    public MemberLikeCountResponse getMemberLikeCount(Long memberId, Long contestId) {
+        contestConvenience.getValidateExistContest(contestId);
+        long currentLikeCount = teamLikeRepository.countMemberLikesInContest(memberId, contestId);
+        long remainingLikeCount = MAX_LIKES_PER_CONTEST - currentLikeCount;
+        return new MemberLikeCountResponse(remainingLikeCount, MAX_LIKES_PER_CONTEST);
     }
 }

--- a/src/main/java/com/ops/ops/modules/team/application/dto/response/MemberLikeCountResponse.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/response/MemberLikeCountResponse.java
@@ -1,6 +1,7 @@
 package com.ops.ops.modules.team.application.dto.response;
 
 public record MemberLikeCountResponse(
-        Long currentMemberLikeCount
+        Long remainingLikeCount,
+        Long maxLikeCount
 ) {
 }

--- a/src/main/java/com/ops/ops/modules/team/application/dto/response/TeamLikeToggleResponse.java
+++ b/src/main/java/com/ops/ops/modules/team/application/dto/response/TeamLikeToggleResponse.java
@@ -4,6 +4,12 @@ public record TeamLikeToggleResponse(
         Long teamId,
         Boolean isLiked,
         String message,
-        Long currentMemberLikeCount
+        Long remainingLikeCount,
+        Long maxLikeCount
 ) {
+    public static TeamLikeToggleResponse of(Long teamId, Boolean isLiked, String message,
+                                            long currentLikeCount, long maxLikeCount) {
+        long remainingLikeCount = maxLikeCount - currentLikeCount;
+        return new TeamLikeToggleResponse(teamId, isLiked, message, remainingLikeCount, maxLikeCount);
+    }
 }


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #141 

## 📜 작업 내용
 
 좋아요 버튼 클릭 시 남은 좋아요 개수를 보여주는 UI를 구성하기 위해 좋아요 관련 APi의 응답값에 남은 좋아요 수, 현재 대회 좋아요 최대 허용 개수를 추가하여 전달하기 위해 리팩토링해주었습니다!

## 💬 리뷰 요구사항



## ✨ 기타
화이팅!
